### PR TITLE
handle missing closing tag in `element-newline` (fixes #30)

### DIFF
--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import("../types").HTMLNode} HTMLNode
+ */
+
 const { RULE_CATEGORY, NODE_TYPES } = require("../constants");
 
 const MESSAGE_IDS = {
@@ -86,12 +90,18 @@ module.exports = {
   },
 };
 
+/**
+ * Checks whether two nodes are on the same line or not.
+ * @param {HTMLNode} nodeBefore A node before
+ * @param {HTMLNode} nodeAfter  A node after
+ * @returns {boolean} `true` if two nodes are on the same line, otherwise `false`.
+ */
 function isOnTheSameLine(nodeBefore, nodeAfter) {
-  return (
-    nodeBefore &&
-    nodeAfter &&
-    nodeBefore.loc &&
-    nodeAfter.loc &&
-    nodeBefore.loc.end.line === nodeAfter.loc.start.line
-  );
+  if (nodeBefore && nodeAfter) {
+    if (nodeBefore.endTag) {
+      return nodeBefore.endTag.loc.end.line === nodeAfter.loc.start.line;
+    }
+    return nodeBefore.loc.start.line === nodeAfter.loc.start.line;
+  }
+  return false;
 }

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -13,6 +13,18 @@ ruleTester.run("element-newline", rule, {
 </html>
 `,
     },
+    {
+      code: `
+      <!DOCTYPE html>
+      <html lang="en">
+          <body>
+              <ul>
+                  <li>Item Here
+                  <li>Second Item Here</li>
+              </ul>
+          </body>
+      </html>`,
+    },
   ],
   invalid: [
     {
@@ -243,6 +255,32 @@ ruleTester.run("element-newline", rule, {
         },
         {
           messageId: "expectBefore",
+        },
+      ],
+    },
+    {
+      code: `
+<!DOCTYPE html>
+<html lang="en">
+    <body>
+        <ul>
+            <li>Item Here <li>Second Item Here</li>
+        </ul>
+    </body>
+</html>`,
+      output: `
+<!DOCTYPE html>
+<html lang="en">
+    <body>
+        <ul>
+            <li>Item Here 
+<li>Second Item Here</li>
+        </ul>
+    </body>
+</html>`,
+      errors: [
+        {
+          messageId: "expectAfter",
         },
       ],
     },


### PR DESCRIPTION
fixes #30 