### PR TITLE
fix: Change comment node type to "Block" to match spaced-comment eslint rule prerequisites

### DIFF
--- a/packages/eslint-plugin/lib/rules/utils/node-utils.js
+++ b/packages/eslint-plugin/lib/rules/utils/node-utils.js
@@ -55,6 +55,6 @@ module.exports = {
    * @returns {node is CommentNode} `true` if a node is `CommentNode`, otherwise `false`.
    */
   isCommentNode(node) {
-    return !!(node && node.type === "comment");
+    return !!(node && node.type === "Block");
   },
 };

--- a/packages/eslint-plugin/lib/types.d.ts
+++ b/packages/eslint-plugin/lib/types.d.ts
@@ -104,7 +104,7 @@ export interface AttrNode extends BaseNode {
 }
 
 export interface CommentNode extends BaseNode {
-  type: "comment";
+  type: "Block";
   value: string;
   startTag?: TagNode;
   endTag?: TagNode;

--- a/packages/parser/lib/postprocessor/postprocessor.js
+++ b/packages/parser/lib/postprocessor/postprocessor.js
@@ -57,7 +57,7 @@ module.exports = class PostProcessor {
 
   ["#comment"](node) {
     this.skipCommonProcess = true;
-    node.type = "comment";
+    node.type = "Block";
     node.startTag = createCommentStartTag(node);
     node.endTag = createCommentEndTag(node);
     node.value = node.data;


### PR DESCRIPTION
For a description of the problem, fix https://github.com/yeonjuan/html-eslint/issues/67