### PR TITLE
CI: Remove redundant test run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,5 +12,4 @@ jobs:
           node-version: 12.x
       - run: npm ci
       - run: npm run bootstrap
-      - run: npm run test
       - run: npm run test:all


### PR DESCRIPTION
`test:all` already includes `npm run test`.