### PR TITLE
Add option disallowMissing to `no-extra-spacing-attrs` rule

### DIFF
--- a/docs/rules/no-extra-spacing-attrs.md
+++ b/docs/rules/no-extra-spacing-attrs.md
@@ -71,7 +71,7 @@ Examples of **correct** code for this rule with the default `{ "enforceBeforeSel
 
 - `disallowMissing` (default: false): Enforce at least one space between attributes
 
-Example(s) of **incorrect** code for this rule with the default `{ "disallowMissing": true }` option:
+Example(s) of **incorrect** code for this rule with the `{ "disallowMissing": true }` option:
 
 <!-- prettier-ignore-start -->
 

--- a/docs/rules/no-extra-spacing-attrs.md
+++ b/docs/rules/no-extra-spacing-attrs.md
@@ -82,7 +82,7 @@ Example(s) of **incorrect** code for this rule with the `{ "disallowMissing": tr
 
 <!-- prettier-ignore-end -->
 
-Example(s) of **correct** code for this rule with the default `{ "disallowMissing": true }` option:
+Example(s) of **correct** code for this rule with the `{ "disallowMissing": true }` option:
 
 <!-- prettier-ignore-start -->
 

--- a/docs/rules/no-extra-spacing-attrs.md
+++ b/docs/rules/no-extra-spacing-attrs.md
@@ -68,3 +68,27 @@ Examples of **correct** code for this rule with the default `{ "enforceBeforeSel
 ```
 
 <!-- prettier-ignore-end -->
+
+- `disallowMissing` (default: false): Enforce at least one space between attributes
+
+Example(s) of **incorrect** code for this rule with the default `{ "disallowMissing": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id="foo"class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+Example(s) of **correct** code for this rule with the default `{ "disallowMissing": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id="foo" class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
@@ -8,6 +8,7 @@ const MESSAGE_IDS = {
   EXTRA_BETWEEN: "unexpectedBetween",
   EXTRA_AFTER: "unexpectedAfter",
   EXTRA_BEFORE: "unexpectedBefore",
+  MISSING_BEFORE: "missingBefore",
   MISSING_BEFORE_SELF_CLOSE: "missingBeforeSelfClose",
   EXTRA_BEFORE_SELF_CLOSE: "unexpectedBeforeSelfClose",
 };
@@ -30,6 +31,9 @@ module.exports = {
       {
         type: "object",
         properties: {
+          disallowMissing: {
+            type: "boolean",
+          },
           enforceBeforeSelfClose: {
             type: "boolean",
           },
@@ -44,11 +48,13 @@ module.exports = {
         "Missing space before self closing",
       [MESSAGE_IDS.EXTRA_BEFORE_SELF_CLOSE]:
         "Unexpected extra spaces before self closing",
+      [MESSAGE_IDS.MISSING_BEFORE]: "Missing space before attribute",
     },
   },
   create(context) {
     const enforceBeforeSelfClose = !!(context.options[0] || {})
       .enforceBeforeSelfClose;
+    const disallowMissing = !!(context.options[0] || {}).disallowMissing;
 
     function checkExtraSpacesBetweenAttrs(attrs) {
       attrs.forEach((current, index, attrs) => {
@@ -67,6 +73,14 @@ module.exports = {
             messageId: MESSAGE_IDS.EXTRA_BETWEEN,
             fix(fixer) {
               return fixer.removeRange([current.range[1] + 1, after.range[0]]);
+            },
+          });
+        } else if (disallowMissing && spacesBetween < 1) {
+          context.report({
+            loc: NodeUtils.getLocBetween(current, after),
+            messageId: MESSAGE_IDS.MISSING_BEFORE,
+            fix(fixer) {
+              return fixer.insertTextAfter(current, " ");
             },
           });
         }

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
@@ -77,7 +77,7 @@ module.exports = {
           });
         } else if (disallowMissing && spacesBetween < 1) {
           context.report({
-            loc: NodeUtils.getLocBetween(current, after),
+            loc: after.loc,
             messageId: MESSAGE_IDS.MISSING_BEFORE,
             fix(fixer) {
               return fixer.insertTextAfter(current, " ");

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
@@ -110,6 +110,25 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
         },
       ],
     },
+    {
+      code: `<img src='foo.png'alt='foo'/>`,
+    },
+    {
+      code: `<img src='foo.png'alt='foo'/>`,
+      options: [
+        {
+          disallowMissing: false,
+        },
+      ],
+    },
+    {
+      code: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowMissing: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -334,6 +353,20 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
       errors: [
         {
           messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: `<img src='foo.png'alt='foo'/>`,
+      output: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowMissing: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "missingBefore",
         },
       ],
     },


### PR DESCRIPTION
This option disallows missing space between attributes.
Closes #119 