### PR TITLE
fix(docs): swap the correct and incorrect examples for `require-meta-viewport`

### DIFF
--- a/docs/rules/require-meta-viewport.md
+++ b/docs/rules/require-meta-viewport.md
@@ -26,7 +26,7 @@ Examples of **incorrect** code for this rule:
 ```html
 <html>
   <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="ESLint plugin for HTML" />
   </head>
 </html>
 ```
@@ -36,7 +36,7 @@ Examples of **correct** code for this rule:
 ```html
 <html>
   <head>
-    <meta name="description" content="ESLint plugin for HTML" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
 </html>
 ```


### PR DESCRIPTION
Hi! 👋 

If I'm correct, the examples on this page are mixed up, given that the current incorrect example is the correct one. This PR serves to swap them, if you think it's relevant. 

Thanks! 😄