### PR TITLE
docs: fix `require-attrs` name in rule list

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -23,7 +23,7 @@ title: Rules
 | [@html-eslint/no-duplicate-attrs](rules/no-duplicate-attrs)     | Disallow to use duplicate attributes                       | ⭐   |
 | [@html-eslint/require-button-type](rules/require-button-type)   | Require use of button element with a valid type attribute. |      |
 | [@html-eslint/no-restricted-attrs](rules/no-restricted-attrs)   | Disallow specified attributes                              |      |
-| [@html-eslint/no-restricted-attrs](rules/require-attrs)         | Enforce to use of specified attributes                     |      |
+| [@html-eslint/require-attrs](rules/require-attrs)               | Enforce to use of specified attributes                     |      |
 
 ### SEO
 


### PR DESCRIPTION
noticed a minor issue in the docs where the `require-attrs` link seems to have been copied from `no-restricted-attrs` without updating the name