### PR TITLE
fix: correct `not-restricted-attr-values` docs title

### DIFF
--- a/docs/rules/no-restricted-attr-values.md
+++ b/docs/rules/no-restricted-attr-values.md
@@ -3,7 +3,7 @@ id: no-restricted-attr-values
 title: "no-restricted-attr-values"
 ---
 
-# no-restricted-attrs
+# no-restricted-attr-values
 
 Disallow specified attribute values
 


### PR DESCRIPTION
Just copied from the docs page to my shared ESLint config and noticed the error :)