### PR TITLE
feat: add "regex" option to `id-naming-convention`

### DIFF
--- a/docs/rules/id-naming-convention.md
+++ b/docs/rules/id-naming-convention.md
@@ -14,7 +14,7 @@ module.exports = {
 
 ## Rule Details
 
-This rule supports 4 naming cases. `camelCase`, `snake_case`, `PascalCase`, `kebab-case` (default `snake_case`).
+This rule supports 4 naming cases. `camelCase`, `snake_case`, `PascalCase`, `kebab-case` (default `snake_case`). It also supports `regex`, which allows you to configure a custom naming convention.
 
 ### Options
 
@@ -22,6 +22,7 @@ This rule supports 4 naming cases. `camelCase`, `snake_case`, `PascalCase`, `keb
 - `"camelCase"`: Enforce camelCase format.
 - `"PascalCase"`: Enforce PascalCase format.
 - `"kebab-case"`: Enforce kebab-case format.
+- `"regex", { "pattern": "^my-regex$" }`: Enforce a format defined by a custom regex.
 
 #### "snake_case" (default)
 
@@ -77,6 +78,32 @@ Examples of **correct** code for this rule with the `"kebab-case"` option:
 
 ```html,correct
 <div id="foo-bar"></div>
+```
+
+### "regex"
+
+Examples of **incorrect** code for this rule with the `"regex"` option below:
+
+```js
+{
+  "@html-eslint/id-naming-convention": ["error", "regex", { "pattern": "^([A-Z][a-z])+[A-Z]?$" }]
+}
+```
+
+```html,incorrect
+<div id="foo_bar"></div>
+```
+
+Examples of **correct** code for this rule with the `"regex"` option below:
+
+```js
+{
+  "@html-eslint/id-naming-convention": ["error", "regex", { "pattern": "^([A-Z][a-z])+[A-Z]?$" }]
+}
+```
+
+```html,correct
+<div id="CuStOmReGeX"></div>
 ```
 
 ## Further Reading

--- a/packages/eslint-plugin/lib/rules/id-naming-convention.js
+++ b/packages/eslint-plugin/lib/rules/id-naming-convention.js
@@ -16,6 +16,7 @@ const CONVENTIONS = {
   SNAKE_CASE: "snake_case",
   PASCAL_CASE: "PascalCase",
   KEBAB_CASE: "kebab-case",
+  REGEX: "regex",
 };
 
 const CONVENTION_CHECKERS = {
@@ -43,6 +44,13 @@ module.exports = {
       {
         enum: Object.values(CONVENTIONS),
       },
+      {
+          type: "object",
+          properties: {
+              pattern: { type: "string" }
+          },
+          additionalProperties: false
+      }
     ],
     messages: {
       [MESSAGE_IDS.WRONG]:
@@ -56,7 +64,7 @@ module.exports = {
         ? context.options[0]
         : CONVENTIONS.SNAKE_CASE;
 
-    const checkNaming = CONVENTION_CHECKERS[convention];
+    const checkNaming = convention === CONVENTIONS.REGEX ? (name) => new RegExp(context.options[1].pattern).test(name) : CONVENTION_CHECKERS[convention];
 
     return {
       /**

--- a/packages/eslint-plugin/lib/rules/id-naming-convention.js
+++ b/packages/eslint-plugin/lib/rules/id-naming-convention.js
@@ -45,12 +45,12 @@ module.exports = {
         enum: Object.values(CONVENTIONS),
       },
       {
-          type: "object",
-          properties: {
-              pattern: { type: "string" }
-          },
-          additionalProperties: false
-      }
+        type: "object",
+        properties: {
+          pattern: { type: "string" },
+        },
+        additionalProperties: false,
+      },
     ],
     messages: {
       [MESSAGE_IDS.WRONG]:
@@ -64,7 +64,10 @@ module.exports = {
         ? context.options[0]
         : CONVENTIONS.SNAKE_CASE;
 
-    const checkNaming = convention === CONVENTIONS.REGEX ? (name) => new RegExp(context.options[1].pattern).test(name) : CONVENTION_CHECKERS[convention];
+    const checkNaming =
+      convention === CONVENTIONS.REGEX
+        ? (name) => new RegExp(context.options[1].pattern).test(name)
+        : CONVENTION_CHECKERS[convention];
 
     return {
       /**

--- a/packages/eslint-plugin/lib/rules/id-naming-convention.js
+++ b/packages/eslint-plugin/lib/rules/id-naming-convention.js
@@ -66,7 +66,8 @@ module.exports = {
 
     const checkNaming =
       convention === CONVENTIONS.REGEX
-        ? (name) => new RegExp(context.options[1].pattern).test(name)
+        ? (/** @type string */ name) =>
+            new RegExp(context.options[1].pattern).test(name)
         : CONVENTION_CHECKERS[convention];
 
     return {

--- a/packages/eslint-plugin/tests/rules/id-naming-convention.test.js
+++ b/packages/eslint-plugin/tests/rules/id-naming-convention.test.js
@@ -21,6 +21,10 @@ ruleTester.run("id-naming-convention", rule, {
       code: `<div id="snake_case"> </div>`,
       options: ["snake_case"],
     },
+    {
+      code: `<div id="CuStOmReGeX"> </div>`,
+      options: ["regex", { pattern: "^([A-Z][a-z])+[A-Z]?$" }],
+    },
   ],
   invalid: [
     {
@@ -38,6 +42,15 @@ ruleTester.run("id-naming-convention", rule, {
       errors: [
         {
           message: "The id 'kebab-case' is not matched with the snake_case.",
+        },
+      ],
+    },
+    {
+      code: `<div id="kebab-case"> </div>`,
+      options: ["regex", { pattern: "^([A-Z][a-z])+[A-Z]?$" }],
+      errors: [
+        {
+          message: "The id 'kebab-case' is not matched with the regex.",
         },
       ],
     },


### PR DESCRIPTION
hey there! i ran into a case where `id-naming-convention` rule would be helpful, but the provided options are too strict to easily adopt (it's a large repo with multiple competing standards). this updates the rule to support a custom regex, which should hopefully make it flexible enough to cover any cases which deviate from the common standards