### PR TITLE
docs: correct spelling of "accessibility"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "publish:alpha": "lerna publish --dist-tag alpha",
     "check:ts": "turbo run ts",
     "check:format": "prettier --check .",
-    "check:spell": "cspell --config .cspell.json \"**/*.{js,ts,tsx,md}\" --quiet",
+    "check:spell": "cspell --config .cspell.json \"**/*.{js,ts,tsx,md,html}\" --quiet",
     "check": "yarn test && yarn check:format && yarn check:spell && yarn check:ts",
     "publish:website": "yarn workspace website deploy"
   },

--- a/packages/website/.posthtmlrc.js
+++ b/packages/website/.posthtmlrc.js
@@ -37,7 +37,7 @@ const expressionsOption = {
       ],
       bestPractice: rules["Best Practice"],
       seo: rules["SEO"],
-      accssibility: rules["Accessibility"],
+      accessibility: rules["Accessibility"],
       style: rules["Style"],
     },
   },

--- a/packages/website/src/components/nav.html
+++ b/packages/website/src/components/nav.html
@@ -3,7 +3,7 @@
     projectNavs: locals.navs.project,
     bestPracticeNavs: locals.navs.bestPractice,
     seoNavs: locals.navs.seo,
-    accssibilityNavs: locals.navs.accssibility,
+    accessibilityNavs: locals.navs.accessibility,
     styleNavs: locals.navs.style
   }
 </script>
@@ -61,9 +61,9 @@
             <li>
                 <module
                     href="/components/nav-list.html"
-                    locals='{ "id": "accesibility-nav", "list": {{accssibilityNavs}} }'>
+                    locals='{ "id": "accessibility-nav", "list": {{accessibilityNavs}} }'>
                     <span class="title5">
-                        Accesibility
+                        Accessibility
                     </span>
                 </module>
             </li>


### PR DESCRIPTION
Thank you for this plugin.

This is just a minor spelling correction, "accesibility" → "accessibility".

Not sure why cspell didn't catch this. 🤷‍♂️