### PR TITLE
feat: better `require-closing-tags` support

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,6 +31,7 @@
     "noembed",
     "roletype",
     "nextid",
-    "screenreader"
+    "screenreader",
+    "mspace"
   ]
 }

--- a/docs/rules/require-closing-tags.md
+++ b/docs/rules/require-closing-tags.md
@@ -39,6 +39,7 @@ This rule has an object option for [Void Elements](https://html.spec.whatwg.org/
 - `"allowSelfClosingCustom": false`: (default) disallow self-closing for the custom tags.
 
 - `"allowSelfClosingCustom": true`: allow self-closing for the custom tags.
+- `"customPattern": "-"`: regex format for tags allowed by `"allowSelfClosingCustom"`.
 
 #### selfClosing : "never"
 
@@ -94,14 +95,54 @@ Examples of **correct** code for the `{ "allowSelfClosingCustom": false }` optio
 
 #### "allowSelfClosingCustom": true
 
+Examples of **incorrect** code for the `{ "allowSelfClosingCustom": false }` option:
+
+<!-- prettier-ignore -->
+```html,incorrect
+<custom-tag> </custom-tag>
+```
+
 Examples of **correct** code for the `{ "allowSelfClosingCustom": true }` option:
 
 <!-- prettier-ignore -->
 ```html,correct
-<!-- both allowed -->
-
-<custom-tag> </custom-tag>
+<custom-tag>children</custom-tag>
 <custom-tag />
+```
+
+#### "customPattern"
+
+Examples of **incorrect** code for the options below:
+
+```js
+{
+  selfClosing: "always",
+  allowSelfClosingCustom: true,
+  customPattern: ":",
+}
+```
+
+<!-- prettier-ignore -->
+```html,incorrect
+<custom:tag></custom:tag>
+<custom-tag />
+```
+
+Examples of **correct** code for the `options below:
+
+```js
+{
+  selfClosing: "always",
+  allowSelfClosingCustom: true,
+  customPattern: ":",
+}
+```
+
+<!-- prettier-ignore -->
+```html,correct
+<custom:tag>children</custom:tag>
+<custom:tag />
+<custom-tag></custom-tag>
 ```
 
 ## Further Reading

--- a/docs/rules/require-closing-tags.md
+++ b/docs/rules/require-closing-tags.md
@@ -128,7 +128,7 @@ Examples of **incorrect** code for the options below:
 <custom-tag />
 ```
 
-Examples of **correct** code for the `options below:
+Examples of **correct** code for the options below:
 
 ```js
 {

--- a/docs/rules/require-closing-tags.md
+++ b/docs/rules/require-closing-tags.md
@@ -39,7 +39,7 @@ This rule has an object option for [Void Elements](https://html.spec.whatwg.org/
 - `"allowSelfClosingCustom": false`: (default) disallow self-closing for the custom tags.
 
 - `"allowSelfClosingCustom": true`: allow self-closing for the custom tags.
-- `"customPattern": "-"`: regex format for tags allowed by `"allowSelfClosingCustom"`.
+- `"customPatterns": ["-"]`: an array of strings representing regular expression pattern, defines tags allowed by `"allowSelfClosingCustom"`.
 
 #### selfClosing : "never"
 
@@ -110,7 +110,7 @@ Examples of **correct** code for the `{ "allowSelfClosingCustom": true }` option
 <custom-tag />
 ```
 
-#### "customPattern"
+#### "customPatterns"
 
 Examples of **incorrect** code for the options below:
 
@@ -118,7 +118,7 @@ Examples of **incorrect** code for the options below:
 {
   selfClosing: "always",
   allowSelfClosingCustom: true,
-  customPattern: ":",
+  customPatterns: [":"],
 }
 ```
 
@@ -134,7 +134,7 @@ Examples of **correct** code for the `options below:
 {
   selfClosing: "always",
   allowSelfClosingCustom: true,
-  customPattern: ":",
+  customPatterns: [":"],
 }
 ```
 

--- a/docs/rules/require-closing-tags.md
+++ b/docs/rules/require-closing-tags.md
@@ -36,9 +36,9 @@ This rule has an object option for [Void Elements](https://html.spec.whatwg.org/
 
 - `"selfClosing": "always"`: enforce using self closing tag on [Void Elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements).
 
-- `"selfClosingCustomPatterns": ["-"]`: (default) an array of strings representing regular expression pattern, enforce self-closing for tags including `-` in the name.
+- `"selfClosingCustomPatterns": []`: (default) disallow self-closing for custom tags.
 
-- `"selfClosingCustomPatterns": []`: disallow self-closing for custom tags.
+- `"selfClosingCustomPatterns": ["-"]`: enforce self-closing for tags matching any of an array of strings representing regular expression pattern (e.g. tags including `-` in the name).
 
 #### selfClosing : "never"
 

--- a/docs/rules/require-closing-tags.md
+++ b/docs/rules/require-closing-tags.md
@@ -30,16 +30,15 @@ Examples of **correct** code for this rule:
 
 ### Options
 
-This rule has an object option for [Void Elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements).
+This rule has an object option for [Void Elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements) and custom element patterns.
 
 - `"selfClosing": "never"`: (default) disallow using self closing tag on [Void Elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements).
 
 - `"selfClosing": "always"`: enforce using self closing tag on [Void Elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements).
 
-- `"allowSelfClosingCustom": false`: (default) disallow self-closing for the custom tags.
+- `"selfClosingCustomPatterns": ["-"]`: (default) an array of strings representing regular expression pattern, enforce self-closing for tags including `-` in the name.
 
-- `"allowSelfClosingCustom": true`: allow self-closing for the custom tags.
-- `"customPatterns": ["-"]`: an array of strings representing regular expression pattern, defines tags allowed by `"allowSelfClosingCustom"`.
+- `"selfClosingCustomPatterns": []`: disallow self-closing for custom tags.
 
 #### selfClosing : "never"
 
@@ -77,32 +76,16 @@ Examples of **correct** code for the `{ "selfClosing": "always" }` option:
 <base />
 ```
 
-#### "allowSelfClosingCustom": false
+#### selfClosingCustomPatterns: ["-"]
 
-Examples of **incorrect** code for the `{ "allowSelfClosingCustom": false }` option:
-
-<!-- prettier-ignore -->
-```html,incorrect
-<custom-tag />
-```
-
-Examples of **correct** code for the `{ "allowSelfClosingCustom": false }` option:
-
-<!-- prettier-ignore -->
-```html,correct
-<custom-tag> </custom-tag>
-```
-
-#### "allowSelfClosingCustom": true
-
-Examples of **incorrect** code for the `{ "allowSelfClosingCustom": false }` option:
+Examples of **incorrect** code for the `{ "selfClosingCustomPatterns": ["-"] }` option:
 
 <!-- prettier-ignore -->
 ```html,incorrect
 <custom-tag> </custom-tag>
 ```
 
-Examples of **correct** code for the `{ "allowSelfClosingCustom": true }` option:
+Examples of **correct** code for the `{ "selfClosingCustomPatterns": ["-"] }` option:
 
 <!-- prettier-ignore -->
 ```html,correct
@@ -110,39 +93,20 @@ Examples of **correct** code for the `{ "allowSelfClosingCustom": true }` option
 <custom-tag />
 ```
 
-#### "customPatterns"
+#### selfClosingCustomPatterns: []
 
-Examples of **incorrect** code for the options below:
-
-```js
-{
-  selfClosing: "always",
-  allowSelfClosingCustom: true,
-  customPatterns: [":"],
-}
-```
+Examples of **incorrect** code for the `{ "allowSelfClosingCustom": [] }` option:
 
 <!-- prettier-ignore -->
 ```html,incorrect
-<custom:tag></custom:tag>
 <custom-tag />
 ```
 
-Examples of **correct** code for the options below:
-
-```js
-{
-  selfClosing: "always",
-  allowSelfClosingCustom: true,
-  customPatterns: [":"],
-}
-```
+Examples of **correct** code for the `{ "allowSelfClosingCustom": [] }` option:
 
 <!-- prettier-ignore -->
 ```html,correct
-<custom:tag>children</custom:tag>
-<custom:tag />
-<custom-tag></custom-tag>
+<custom-tag> </custom-tag>
 ```
 
 ## Further Reading

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -65,12 +65,11 @@ module.exports = {
       context.options && context.options.length
         ? context.options[0].allowSelfClosingCustom === true
         : false;
-    /** @type {RegExp[]} */
-    const customPatterns = (
-      (context.options &&
-        context.options.length &&
-        context.options[0].customPatterns) || ["-"]
-    ).map((i) => new RegExp(i));
+    /** @type {string[]} */
+    const customPatternsOption = (context.options &&
+      context.options.length &&
+      context.options[0].customPatterns) || ["-"];
+    const customPatterns = customPatternsOption.map((i) => new RegExp(i));
 
     /**
      * @param {TagNode} node

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -66,11 +66,11 @@ module.exports = {
         ? context.options[0].allowSelfClosingCustom === true
         : false;
     /** @type {RegExp[]} */
-    const customPatterns = 
-      ((context.options &&
+    const customPatterns = (
+      (context.options &&
         context.options.length &&
-        context.options[0].customPatterns) ||
-        ["-"]).map(i => new RegExp(i));
+        context.options[0].customPatterns) || ["-"]
+    ).map((i) => new RegExp(i));
 
     /**
      * @param {TagNode} node
@@ -129,7 +129,9 @@ module.exports = {
     return {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
-        const isCustomElement = !!customPatterns.some(i => node.name.match(i));
+        const isCustomElement = !!customPatterns.some((i) =>
+          node.name.match(i)
+        );
         const canSelfClose =
           isVoidElement ||
           foreignContext.length > 0 ||

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -37,8 +37,11 @@ module.exports = {
           allowSelfClosingCustom: {
             type: "boolean",
           },
-          customPattern: {
-            type: "string",
+          customPatterns: {
+            type: "array",
+            items: {
+              type: "string",
+            },
           },
         },
         additionalProperties: false,
@@ -62,12 +65,12 @@ module.exports = {
       context.options && context.options.length
         ? context.options[0].allowSelfClosingCustom === true
         : false;
-    const customPattern = new RegExp(
-      (context.options &&
+    /** @type {RegExp[]} */
+    const customPatterns = 
+      ((context.options &&
         context.options.length &&
-        context.options[0].customPattern) ||
-        "-"
-    );
+        context.options[0].customPatterns) ||
+        ["-"]).map(i => new RegExp(i));
 
     /**
      * @param {TagNode} node
@@ -126,7 +129,7 @@ module.exports = {
     return {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
-        const isCustomElement = !!node.name.match(customPattern);
+        const isCustomElement = !!customPatterns.some(i => node.name.match(i));
         const canSelfClose =
           isVoidElement ||
           foreignContext.length > 0 ||

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -116,7 +116,6 @@ module.exports = {
 
     return {
       Tag(node) {
-        if (['svg', 'math'].includes(node.name)) foreignContext.push(node.name);
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
         const canSelfClose = isVoidElement || foreignContext.length > 0;
         if (
@@ -130,6 +129,7 @@ module.exports = {
         } else if (node.openEnd.value !== "/>") {
           checkClosingTag(node);
         }
+        if (['svg', 'math'].includes(node.name)) foreignContext.push(node.name);
       },
       /**
        * @param {TagNode} node

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -49,6 +49,8 @@ module.exports = {
   },
 
   create(context) {
+    /** @type {string[]} */
+    const foreignContext = [];
     const preferSelfClose =
       context.options && context.options.length
         ? context.options[0].selfClosing === "always"
@@ -114,8 +116,9 @@ module.exports = {
 
     return {
       Tag(node) {
+        if (['svg', 'math'].includes(node.name)) foreignContext.push(node.name);
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
-        const canSelfClose = isVoidElement;
+        const canSelfClose = isVoidElement || foreignContext.length > 0;
         if (
           node.selfClosing &&
           allowSelfClosingCustom &&
@@ -126,6 +129,14 @@ module.exports = {
           checkVoidElement(node, preferSelfClose && canSelfClose, canSelfClose);
         } else if (node.openEnd.value !== "/>") {
           checkClosingTag(node);
+        }
+      },
+      /**
+       * @param {TagNode} node
+       */
+      "Tag:exit"(node) {
+        if (node.name === foreignContext[foreignContext.length-1]) {
+          foreignContext.pop();
         }
       },
     };

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -104,7 +104,10 @@ module.exports = {
             if (!fixable) {
               return null;
             }
-            return fixer.replaceText(node.openEnd, " />");
+            return [
+              fixer.replaceText(node.openEnd, " />"),
+              fixer.remove(node.close),
+            ];
           },
         });
       }

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -59,9 +59,11 @@ module.exports = {
         ? context.options[0].selfClosing === "always"
         : false;
     /** @type {string[]} */
-    const selfClosingCustomPatternsOption = (context.options &&
-      context.options.length &&
-      context.options[0].selfClosingCustomPatterns) || [];
+    const selfClosingCustomPatternsOption =
+      (context.options &&
+        context.options.length &&
+        context.options[0].selfClosingCustomPatterns) ||
+      [];
     const selfClosingCustomPatterns = selfClosingCustomPatternsOption.map(
       (i) => new RegExp(i)
     );

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -61,7 +61,7 @@ module.exports = {
     /** @type {string[]} */
     const selfClosingCustomPatternsOption = (context.options &&
       context.options.length &&
-      context.options[0].selfClosingCustomPatterns) || ["-"];
+      context.options[0].selfClosingCustomPatterns) || [];
     const selfClosingCustomPatterns = selfClosingCustomPatternsOption.map(
       (i) => new RegExp(i)
     );

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -122,7 +122,7 @@ module.exports = {
         ) {
           checkVoidElement(node, true, false);
         } else if (node.selfClosing || isVoidElement) {
-          checkVoidElement(node, shouldSelfClose, isVoidElement);
+          checkVoidElement(node, shouldSelfClose && isVoidElement, isVoidElement);
         } else if (node.openEnd.value !== "/>") {
           checkClosingTag(node);
         }

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -49,7 +49,7 @@ module.exports = {
   },
 
   create(context) {
-    const shouldSelfClose =
+    const preferSelfClose =
       context.options && context.options.length
         ? context.options[0].selfClosing === "always"
         : false;
@@ -115,6 +115,7 @@ module.exports = {
     return {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
+        const canSelfClose = isVoidElement;
         if (
           node.selfClosing &&
           allowSelfClosingCustom &&
@@ -122,7 +123,7 @@ module.exports = {
         ) {
           checkVoidElement(node, true, false);
         } else if (node.selfClosing || isVoidElement) {
-          checkVoidElement(node, shouldSelfClose && isVoidElement, isVoidElement);
+          checkVoidElement(node, preferSelfClose && canSelfClose, canSelfClose);
         } else if (node.openEnd.value !== "/>") {
           checkClosingTag(node);
         }

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -62,7 +62,9 @@ module.exports = {
     const selfClosingCustomPatternsOption = (context.options &&
       context.options.length &&
       context.options[0].selfClosingCustomPatterns) || ["-"];
-    const selfClosingCustomPatterns = selfClosingCustomPatternsOption.map((i) => new RegExp(i));
+    const selfClosingCustomPatterns = selfClosingCustomPatternsOption.map(
+      (i) => new RegExp(i)
+    );
 
     /**
      * @param {TagNode} node
@@ -124,12 +126,19 @@ module.exports = {
     return {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
-        const isSelfClosingCustomElement = !!selfClosingCustomPatterns.some((i) => node.name.match(i));
+        const isSelfClosingCustomElement = !!selfClosingCustomPatterns.some(
+          (i) => node.name.match(i)
+        );
         const isForeign = foreignContext.length > 0;
-        const shouldSelfCloseCustom = isSelfClosingCustomElement && !node.children.length;
+        const shouldSelfCloseCustom =
+          isSelfClosingCustomElement && !node.children.length;
         const shouldSelfCloseForeign = node.selfClosing;
-        const shouldSelfClose = (isVoidElement && shouldSelfCloseVoid) || (isSelfClosingCustomElement && shouldSelfCloseCustom) || (isForeign && shouldSelfCloseForeign);
-        const canSelfClose = isVoidElement || isSelfClosingCustomElement || isForeign;
+        const shouldSelfClose =
+          (isVoidElement && shouldSelfCloseVoid) ||
+          (isSelfClosingCustomElement && shouldSelfCloseCustom) ||
+          (isForeign && shouldSelfCloseForeign);
+        const canSelfClose =
+          isVoidElement || isSelfClosingCustomElement || isForeign;
         if (node.selfClosing || canSelfClose) {
           checkVoidElement(node, shouldSelfClose, canSelfClose);
         } else if (node.openEnd.value !== "/>") {

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -117,14 +117,9 @@ module.exports = {
     return {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
-        const canSelfClose = isVoidElement || foreignContext.length > 0;
-        if (
-          node.selfClosing &&
-          allowSelfClosingCustom &&
-          node.name.indexOf("-") !== -1
-        ) {
-          checkVoidElement(node, true, false);
-        } else if (node.selfClosing || isVoidElement) {
+        const isCustomElement = node.name.indexOf("-") !== -1;
+        const canSelfClose = isVoidElement || foreignContext.length > 0 || (isCustomElement && allowSelfClosingCustom && !node.children.length);
+        if (node.selfClosing || canSelfClose) {
           checkVoidElement(node, preferSelfClose && canSelfClose, canSelfClose);
         } else if (node.openEnd.value !== "/>") {
           checkClosingTag(node);

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -37,6 +37,9 @@ module.exports = {
           allowSelfClosingCustom: {
             type: "boolean",
           },
+          customPattern: {
+            type: "string",
+          },
         },
         additionalProperties: false,
       },
@@ -59,6 +62,8 @@ module.exports = {
       context.options && context.options.length
         ? context.options[0].allowSelfClosingCustom === true
         : false;
+        const customPattern =
+        new RegExp(context.options && context.options.length && context.options[0].customPattern || '-');
 
     /**
      * @param {TagNode} node
@@ -117,7 +122,7 @@ module.exports = {
     return {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
-        const isCustomElement = node.name.indexOf("-") !== -1;
+        const isCustomElement = !!node.name.match(customPattern);
         const canSelfClose = isVoidElement || foreignContext.length > 0 || (isCustomElement && allowSelfClosingCustom && !node.children.length);
         if (node.selfClosing || canSelfClose) {
           checkVoidElement(node, preferSelfClose && canSelfClose, canSelfClose);

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -62,8 +62,12 @@ module.exports = {
       context.options && context.options.length
         ? context.options[0].allowSelfClosingCustom === true
         : false;
-        const customPattern =
-        new RegExp(context.options && context.options.length && context.options[0].customPattern || '-');
+    const customPattern = new RegExp(
+      (context.options &&
+        context.options.length &&
+        context.options[0].customPattern) ||
+        "-"
+    );
 
     /**
      * @param {TagNode} node
@@ -123,19 +127,22 @@ module.exports = {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
         const isCustomElement = !!node.name.match(customPattern);
-        const canSelfClose = isVoidElement || foreignContext.length > 0 || (isCustomElement && allowSelfClosingCustom && !node.children.length);
+        const canSelfClose =
+          isVoidElement ||
+          foreignContext.length > 0 ||
+          (isCustomElement && allowSelfClosingCustom && !node.children.length);
         if (node.selfClosing || canSelfClose) {
           checkVoidElement(node, preferSelfClose && canSelfClose, canSelfClose);
         } else if (node.openEnd.value !== "/>") {
           checkClosingTag(node);
         }
-        if (['svg', 'math'].includes(node.name)) foreignContext.push(node.name);
+        if (["svg", "math"].includes(node.name)) foreignContext.push(node.name);
       },
       /**
        * @param {TagNode} node
        */
       "Tag:exit"(node) {
-        if (node.name === foreignContext[foreignContext.length-1]) {
+        if (node.name === foreignContext[foreignContext.length - 1]) {
           foreignContext.pop();
         }
       },

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -104,10 +104,10 @@ module.exports = {
             if (!fixable) {
               return null;
             }
-            return [
-              fixer.replaceText(node.openEnd, " />"),
-              fixer.remove(node.close),
-            ];
+            const fixes = [];
+            fixes.push(fixer.replaceText(node.openEnd, " />"));
+            if (node.close) fixes.push(fixer.remove(node.close));
+            return fixes;
           },
         });
       }

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -77,7 +77,7 @@ ruleTester.run("require-closing-tags", rule, {
         {
           selfClosing: "always",
           allowSelfClosingCustom: true,
-          customPattern: ':',
+          customPattern: ":",
         },
       ],
     },
@@ -207,7 +207,7 @@ ruleTester.run("require-closing-tags", rule, {
         {
           selfClosing: "always",
           allowSelfClosingCustom: true,
-          customPattern: ':',
+          customPattern: ":",
         },
       ],
       output: null,
@@ -225,7 +225,7 @@ ruleTester.run("require-closing-tags", rule, {
           allowSelfClosingCustom: true,
         },
       ],
-      output: '<custom-tag /></custom-tag>',
+      output: "<custom-tag /></custom-tag>",
       errors: [
         {
           messageId: "missingSelf",

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -63,6 +63,15 @@ ruleTester.run("require-closing-tags", rule, {
       ],
     },
     {
+      code: `<custom-tag>children</custom-tag>`,
+      options: [
+        {
+          selfClosing: "always",
+          allowSelfClosingCustom: true,
+        },
+      ],
+    },
+    {
       code: `
     <body>
       <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -31,7 +31,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag/>`,
       options: [
         {
-          selfClosingCustomPatterns: ['-'],
+          selfClosingCustomPatterns: ["-"],
         },
       ],
     },
@@ -39,7 +39,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag />`,
       options: [
         {
-          selfClosingCustomPatterns: ['-'],
+          selfClosingCustomPatterns: ["-"],
         },
       ],
     },
@@ -47,7 +47,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag> </custom-tag>`,
       options: [
         {
-          selfClosingCustomPatterns: ['-'],
+          selfClosingCustomPatterns: ["-"],
         },
       ],
     },
@@ -55,7 +55,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag id="foo" />`,
       options: [
         {
-          selfClosingCustomPatterns: ['-'],
+          selfClosingCustomPatterns: ["-"],
         },
       ],
     },
@@ -63,7 +63,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag>children</custom-tag>`,
       options: [
         {
-          selfClosingCustomPatterns: ['-'],
+          selfClosingCustomPatterns: ["-"],
         },
       ],
     },
@@ -190,7 +190,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag></custom-tag>`,
       options: [
         {
-          selfClosingCustomPatterns: ['-'],
+          selfClosingCustomPatterns: ["-"],
         },
       ],
       output: "<custom-tag />",

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -31,6 +31,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag/>`,
       options: [
         {
+          selfClosing: "always",
           allowSelfClosingCustom: true,
         },
       ],
@@ -39,6 +40,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag />`,
       options: [
         {
+          selfClosing: "always",
           allowSelfClosingCustom: true,
         },
       ],
@@ -55,6 +57,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag id="foo" />`,
       options: [
         {
+          selfClosing: "always",
           allowSelfClosingCustom: true,
         },
       ],

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -77,7 +77,7 @@ ruleTester.run("require-closing-tags", rule, {
         {
           selfClosing: "always",
           allowSelfClosingCustom: true,
-          customPattern: ":",
+          customPatterns: [":"],
         },
       ],
     },
@@ -207,7 +207,7 @@ ruleTester.run("require-closing-tags", rule, {
         {
           selfClosing: "always",
           allowSelfClosingCustom: true,
-          customPattern: ":",
+          customPatterns: [":"],
         },
       ],
       output: null,

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -72,6 +72,16 @@ ruleTester.run("require-closing-tags", rule, {
       ],
     },
     {
+      code: `<custom:tag />`,
+      options: [
+        {
+          selfClosing: "always",
+          allowSelfClosingCustom: true,
+          customPattern: ':',
+        },
+      ],
+    },
+    {
       code: `
     <body>
       <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
@@ -182,6 +192,22 @@ ruleTester.run("require-closing-tags", rule, {
       options: [
         {
           allowSelfClosingCustom: false,
+        },
+      ],
+      output: null,
+      errors: [
+        {
+          messageId: "unexpected",
+        },
+      ],
+    },
+    {
+      code: `<custom-tag id="foo" />`,
+      options: [
+        {
+          selfClosing: "always",
+          allowSelfClosingCustom: true,
+          customPattern: ':',
         },
       ],
       output: null,

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -23,7 +23,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag> </custom-tag>`,
       options: [
         {
-          allowSelfClosingCustom: false,
+          selfClosingCustomPatterns: [],
         },
       ],
     },
@@ -31,8 +31,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag/>`,
       options: [
         {
-          selfClosing: "always",
-          allowSelfClosingCustom: true,
+          selfClosingCustomPatterns: ['-'],
         },
       ],
     },
@@ -40,8 +39,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag />`,
       options: [
         {
-          selfClosing: "always",
-          allowSelfClosingCustom: true,
+          selfClosingCustomPatterns: ['-'],
         },
       ],
     },
@@ -49,7 +47,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag> </custom-tag>`,
       options: [
         {
-          allowSelfClosingCustom: true,
+          selfClosingCustomPatterns: ['-'],
         },
       ],
     },
@@ -57,8 +55,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag id="foo" />`,
       options: [
         {
-          selfClosing: "always",
-          allowSelfClosingCustom: true,
+          selfClosingCustomPatterns: ['-'],
         },
       ],
     },
@@ -66,18 +63,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag>children</custom-tag>`,
       options: [
         {
-          selfClosing: "always",
-          allowSelfClosingCustom: true,
-        },
-      ],
-    },
-    {
-      code: `<custom:tag />`,
-      options: [
-        {
-          selfClosing: "always",
-          allowSelfClosingCustom: true,
-          customPatterns: [":"],
+          selfClosingCustomPatterns: ['-'],
         },
       ],
     },
@@ -178,7 +164,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag />`,
       options: [
         {
-          allowSelfClosingCustom: false,
+          selfClosingCustomPatterns: [],
         },
       ],
       errors: [
@@ -191,26 +177,9 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag id="foo" />`,
       options: [
         {
-          allowSelfClosingCustom: false,
+          selfClosingCustomPatterns: [],
         },
       ],
-      output: null,
-      errors: [
-        {
-          messageId: "unexpected",
-        },
-      ],
-    },
-    {
-      code: `<custom-tag id="foo" />`,
-      options: [
-        {
-          selfClosing: "always",
-          allowSelfClosingCustom: true,
-          customPatterns: [":"],
-        },
-      ],
-      output: null,
       errors: [
         {
           messageId: "unexpected",
@@ -221,8 +190,7 @@ ruleTester.run("require-closing-tags", rule, {
       code: `<custom-tag></custom-tag>`,
       options: [
         {
-          selfClosing: "always",
-          allowSelfClosingCustom: true,
+          selfClosingCustomPatterns: ['-'],
         },
       ],
       output: "<custom-tag />",

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -225,7 +225,7 @@ ruleTester.run("require-closing-tags", rule, {
           allowSelfClosingCustom: true,
         },
       ],
-      output: "<custom-tag /></custom-tag>",
+      output: "<custom-tag />",
       errors: [
         {
           messageId: "missingSelf",

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -218,6 +218,21 @@ ruleTester.run("require-closing-tags", rule, {
       ],
     },
     {
+      code: `<custom-tag></custom-tag>`,
+      options: [
+        {
+          selfClosing: "always",
+          allowSelfClosingCustom: true,
+        },
+      ],
+      output: '<custom-tag /></custom-tag>',
+      errors: [
+        {
+          messageId: "missingSelf",
+        },
+      ],
+    },
+    {
       code: `<div />`,
       options: [
         {

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -165,5 +165,19 @@ ruleTester.run("require-closing-tags", rule, {
         },
       ],
     },
+    {
+      code: `<div />`,
+      options: [
+        {
+          selfClosing: "always",
+        },
+      ],
+      output: null,
+      errors: [
+        {
+          messageId: "unexpected",
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -82,6 +82,20 @@ ruleTester.run("require-closing-tags", rule, {
         },
       ],
     },
+    {
+      code: `
+    <body>
+      <math>
+        1<mspace width="100px" />2
+      </math>
+    </body>
+`,
+      options: [
+        {
+          selfClosing: "always",
+        },
+      ],
+    },
     // https://github.com/yeonjuan/html-eslint/issues/73
     {
       code: `


### PR DESCRIPTION
Hey there! I ran into an issue using `require-closing-tags` with the `selfClosing: "always"` option where non-void elements were not being checked correctly. For example:

```js
"@html-eslint/require-closing-tags": ["error", { "selfClosing": "always" }],
```
```html
<div />
```
In this case `<div />` is incorrect (`div` is not a void element and cannot self-close), but the linter would not catch it.

The scope of this fix ended up being larger than expected: custom tags which did not use `-` as part of their naming convention and tags in a foreign context were not explicitly supported, and instead seemed to be handled via this bug. To compensate, I've re-implemented a version of the stack-based approach for handling foreign context seen in earlier implementations of the rule, and added a `customPattern` regex option to allow users to expand the list of allowed elements to include their own self-closing tags (this addresses #183 as a side effect).

I've configured `customPattern`'s default to `"-"` since that matches the previous implementation of the custom element check, but because custom tags are now being enforced instead of ignored and also include a check for child nodes (unlike void elements, it can't be assumed that self-closing tags cannot have children since the implementation is up to the user), this is still a breaking change.