### PR TITLE
feat: add test for tabs in no-extra-spacing-attrs

### DIFF
--- a/docs/rules/no-extra-spacing-attrs.md
+++ b/docs/rules/no-extra-spacing-attrs.md
@@ -1,6 +1,6 @@
 # no-extra-spacing-attrs
 
-This rule disallows extra spaces around attributes.
+This rule disallows extra spaces around attributes, and/or between the tag start and end
 
 ## How to use
 
@@ -26,6 +26,9 @@ Examples of **incorrect** code for this rule:
 
 <!-- an extra space between tag end and attribute -->
 <div foo="foo" ></div>
+
+<!-- an extra space between tag start and end -->
+<div ></div>
 ```
 
 Examples of **correct** code for this rule:
@@ -33,6 +36,7 @@ Examples of **correct** code for this rule:
 ```html,correct
 <div foo="foo" bar="bar"></div>
 <div foo="foo"></div>
+<div></div>
 ```
 
 ## Options
@@ -75,6 +79,30 @@ Example(s) of **incorrect** code for this rule with the `{ "disallowMissing": tr
 <!-- prettier-ignore-end -->
 
 Example(s) of **correct** code for this rule with the `{ "disallowMissing": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id="foo" class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+- `disallowTabs` (default: false): Enforce using spaces instead of tabs between attributes
+
+Example(s) of **incorrect** code for this rule with the `{ "disallowTabs": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div	id="foo"	class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+Example(s) of **correct** code for this rule with the `{ "disallowTabs": true }` option:
 
 <!-- prettier-ignore-start -->
 

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
@@ -163,10 +163,7 @@ module.exports = {
             messageId: MESSAGE_IDS.EXTRA_TAB_BEFORE,
             fix(fixer) {
               return fixer.replaceTextRange(
-                [
-                  firstAttr.range[0] - 1,
-                  firstAttr.range[0]
-                ],
+                [firstAttr.range[0] - 1, firstAttr.range[0]],
                 ` `
               );
             },
@@ -225,10 +222,7 @@ module.exports = {
                   messageId: MESSAGE_IDS.EXTRA_TAB_BEFORE_SELF_CLOSE,
                   fix(fixer) {
                     return fixer.replaceTextRange(
-                      [
-                        node.openEnd.range[0] - 1,
-                        node.openEnd.range[0],
-                      ],
+                      [node.openEnd.range[0] - 1, node.openEnd.range[0]],
                       ` `
                     );
                   },

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
@@ -69,9 +69,12 @@ module.exports = {
       [MESSAGE_IDS.EXTRA_BEFORE_SELF_CLOSE]:
         "Unexpected extra spaces before self closing",
       [MESSAGE_IDS.MISSING_BEFORE]: "Missing space before attribute",
-      [MESSAGE_IDS.EXTRA_TAB_BEFORE]: "Unexpected tab before attribute; use space instead",
-      [MESSAGE_IDS.EXTRA_TAB_BEFORE_SELF_CLOSE]: "Unexpected tab before self closing; use space instead",
-      [MESSAGE_IDS.EXTRA_TAB_BETWEEN]: "Unexpected tab between attributes; use space instead"
+      [MESSAGE_IDS.EXTRA_TAB_BEFORE]:
+        "Unexpected tab before attribute; use space instead",
+      [MESSAGE_IDS.EXTRA_TAB_BEFORE_SELF_CLOSE]:
+        "Unexpected tab before self closing; use space instead",
+      [MESSAGE_IDS.EXTRA_TAB_BETWEEN]:
+        "Unexpected tab between attributes; use space instead",
     },
   },
   create(context) {
@@ -118,7 +121,10 @@ module.exports = {
               loc: getLocBetween(current, after),
               messageId: MESSAGE_IDS.EXTRA_TAB_BETWEEN,
               fix(fixer) {
-                return fixer.replaceTextRange([current.loc.end.column, after.loc.start.column], ` `);
+                return fixer.replaceTextRange(
+                  [current.loc.end.column, after.loc.start.column],
+                  ` `
+                );
               },
             });
           }
@@ -156,7 +162,10 @@ module.exports = {
             loc: firstAttr.loc,
             messageId: MESSAGE_IDS.EXTRA_TAB_BEFORE,
             fix(fixer) {
-              return fixer.replaceTextRange([firstAttr.loc.start.column - 1, firstAttr.loc.start.column], ` `);
+              return fixer.replaceTextRange(
+                [firstAttr.loc.start.column - 1, firstAttr.loc.start.column],
+                ` `
+              );
             },
           });
         }
@@ -180,14 +189,14 @@ module.exports = {
           checkExtraSpacesBetweenAttrs(node.attributes);
 
           const lastAttr = node.attributes[node.attributes.length - 1];
-          const nodeBeforeEnd = node.attributes.length === 0
-            ? node.openStart
-            : lastAttr;
+          const nodeBeforeEnd =
+            node.attributes.length === 0 ? node.openStart : lastAttr;
 
           if (nodeBeforeEnd.loc.end.line === node.openEnd.loc.start.line) {
             const isSelfClosing = node.openEnd.value === "/>";
 
-            const spacesBetween = node.openEnd.loc.start.column - nodeBeforeEnd.loc.end.column;
+            const spacesBetween =
+              node.openEnd.loc.start.column - nodeBeforeEnd.loc.end.column;
             const locBetween = getLocBetween(nodeBeforeEnd, node.openEnd);
 
             if (isSelfClosing && enforceBeforeSelfClose) {
@@ -201,15 +210,18 @@ module.exports = {
                 });
               } else if (spacesBetween === 1) {
                 if (
-                  disallowTabs
-                  && sourceCode[node.openEnd.loc.start.column - 1] === `\t`
+                  disallowTabs &&
+                  sourceCode[node.openEnd.loc.start.column - 1] === `\t`
                 ) {
                   context.report({
                     loc: node.openEnd.loc,
                     messageId: MESSAGE_IDS.EXTRA_TAB_BEFORE_SELF_CLOSE,
                     fix(fixer) {
                       return fixer.replaceTextRange(
-                        [node.openEnd.loc.start.column - 1, node.openEnd.loc.start.column],
+                        [
+                          node.openEnd.loc.start.column - 1,
+                          node.openEnd.loc.start.column,
+                        ],
                         ` `
                       );
                     },
@@ -236,7 +248,7 @@ module.exports = {
                     fix(fixer) {
                       return fixer.removeRange([
                         lastAttr.range[1],
-                        node.openEnd.range[0]
+                        node.openEnd.range[0],
                       ]);
                     },
                   });
@@ -247,10 +259,10 @@ module.exports = {
                     fix(fixer) {
                       return fixer.removeRange([
                         node.openStart.range[1],
-                        node.openEnd.range[0]
+                        node.openEnd.range[0],
                       ]);
-                    }
-                  })
+                    },
+                  });
                 }
               }
             }

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
@@ -122,7 +122,7 @@ module.exports = {
               messageId: MESSAGE_IDS.EXTRA_TAB_BETWEEN,
               fix(fixer) {
                 return fixer.replaceTextRange(
-                  [current.loc.end.column, after.loc.start.column],
+                  [current.range[1], current.range[1] + 1],
                   ` `
                 );
               },

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
@@ -116,7 +116,7 @@ module.exports = {
             },
           });
         } else if (disallowTabs) {
-          if (sourceCode[current.loc.end.column] === `\t`) {
+          if (sourceCode[current.range[1]] === `\t`) {
             context.report({
               loc: getLocBetween(current, after),
               messageId: MESSAGE_IDS.EXTRA_TAB_BETWEEN,
@@ -157,13 +157,16 @@ module.exports = {
           },
         });
       } else if (disallowTabs) {
-        if (sourceCode[firstAttr.loc.start.column - 1] === `\t`) {
+        if (sourceCode[firstAttr.range[0] - 1] === `\t`) {
           context.report({
             loc: firstAttr.loc,
             messageId: MESSAGE_IDS.EXTRA_TAB_BEFORE,
             fix(fixer) {
               return fixer.replaceTextRange(
-                [firstAttr.loc.start.column - 1, firstAttr.loc.start.column],
+                [
+                  firstAttr.range[0] - 1,
+                  firstAttr.range[0]
+                ],
                 ` `
               );
             },
@@ -185,6 +188,7 @@ module.exports = {
         if (node.attributes.length) {
           checkExtraSpaceBefore(node.openStart, node.attributes[0]);
         }
+
         if (node.openEnd) {
           checkExtraSpacesBetweenAttrs(node.attributes);
 
@@ -214,7 +218,7 @@ module.exports = {
             } else if (spacesBetween === 1) {
               if (
                 disallowTabs &&
-                sourceCode[node.openEnd.loc.start.column - 1] === `\t`
+                sourceCode[node.openEnd.range[0] - 1] === `\t`
               ) {
                 context.report({
                   loc: node.openEnd.loc,
@@ -222,8 +226,8 @@ module.exports = {
                   fix(fixer) {
                     return fixer.replaceTextRange(
                       [
-                        node.openEnd.loc.start.column - 1,
-                        node.openEnd.loc.start.column,
+                        node.openEnd.range[0] - 1,
+                        node.openEnd.range[0],
                       ],
                       ` `
                     );

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
@@ -383,5 +383,48 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
         },
       ],
     },
+    {
+      code: `<img src='foo.png'\talt='foo'/>`,
+      output: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowTabs: true,
+        }
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBetween"
+        }
+      ]
+    },
+    {
+      code: `<img\tsrc='foo.png' alt='foo'/>`,
+      output: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowTabs: true,
+        }
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBefore"
+        }
+      ]
+    },
+    {
+      code: `<img\t/>`,
+      output: `<img />`,
+      options: [
+        {
+          disallowTabs: true,
+          enforceBeforeSelfClose: true,
+        }
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBeforeSelfClose"
+        }
+      ]
+    }
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
@@ -144,10 +144,10 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
         {
           disallowMissing: true,
           disallowTabs: true,
-          enforceBeforeSelfClose: true
-        }
-      ]
-    }
+          enforceBeforeSelfClose: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
@@ -309,7 +309,7 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
       output: "<img src='foo.png' />",
       errors: [
         {
-          messageId: "unexpectedAfter",
+          messageId: "unexpectedBeforeSelfClose",
         },
       ],
     },
@@ -425,6 +425,42 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
           messageId: "unexpectedTabBeforeSelfClose"
         }
       ]
-    }
+    },
+    {
+      code: `<div ></div>`,
+      output: `<div></div>`,
+      errors: [
+        {
+          messageId: "unexpectedBeforeClose"
+        }
+      ]
+    },
+    {
+      code: `<div foo="bar" ></div>`,
+      output: `<div foo="bar"></div>`,
+      errors: [
+        {
+          messageId: "unexpectedAfter"
+        }
+      ]
+    },
+    {
+      code: `<div\t></div>`,
+      output: `<div></div>`,
+      errors: [
+        {
+          messageId: "unexpectedBeforeClose"
+        }
+      ]
+    },
+    {
+      code: `<div foo="bar"\t></div>`,
+      output: `<div foo="bar"></div>`,
+      errors: [
+        {
+          messageId: "unexpectedAfter"
+        }
+      ]
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
@@ -477,5 +477,43 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
         },
       ],
     },
+    {
+      code: `
+\t<div>
+\t\t<img\tsrc="foo"\t/>
+\t\t<div\tfoo="bar"\tbar="baz"\t></div>
+\t</div>
+`,
+      output: `
+\t<div>
+\t\t<img src="foo" />
+\t\t<div foo="bar" bar="baz"></div>
+\t</div>
+`,
+      options: [
+        {
+          disallowMissing: true,
+          disallowTabs: true,
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBefore",
+        },
+        {
+          messageId: "unexpectedTabBeforeSelfClose",
+        },
+        {
+          messageId: "unexpectedTabBefore",
+        },
+        {
+          messageId: "unexpectedTabBetween",
+        },
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
@@ -389,13 +389,13 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
       options: [
         {
           disallowTabs: true,
-        }
+        },
       ],
       errors: [
         {
-          messageId: "unexpectedTabBetween"
-        }
-      ]
+          messageId: "unexpectedTabBetween",
+        },
+      ],
     },
     {
       code: `<img\tsrc='foo.png' alt='foo'/>`,
@@ -403,13 +403,13 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
       options: [
         {
           disallowTabs: true,
-        }
+        },
       ],
       errors: [
         {
-          messageId: "unexpectedTabBefore"
-        }
-      ]
+          messageId: "unexpectedTabBefore",
+        },
+      ],
     },
     {
       code: `<img\t/>`,
@@ -418,49 +418,49 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
         {
           disallowTabs: true,
           enforceBeforeSelfClose: true,
-        }
+        },
       ],
       errors: [
         {
-          messageId: "unexpectedTabBeforeSelfClose"
-        }
-      ]
+          messageId: "unexpectedTabBeforeSelfClose",
+        },
+      ],
     },
     {
       code: `<div ></div>`,
       output: `<div></div>`,
       errors: [
         {
-          messageId: "unexpectedBeforeClose"
-        }
-      ]
+          messageId: "unexpectedBeforeClose",
+        },
+      ],
     },
     {
       code: `<div foo="bar" ></div>`,
       output: `<div foo="bar"></div>`,
       errors: [
         {
-          messageId: "unexpectedAfter"
-        }
-      ]
+          messageId: "unexpectedAfter",
+        },
+      ],
     },
     {
       code: `<div\t></div>`,
       output: `<div></div>`,
       errors: [
         {
-          messageId: "unexpectedBeforeClose"
-        }
-      ]
+          messageId: "unexpectedBeforeClose",
+        },
+      ],
     },
     {
       code: `<div foo="bar"\t></div>`,
       output: `<div foo="bar"></div>`,
       errors: [
         {
-          messageId: "unexpectedAfter"
-        }
-      ]
+          messageId: "unexpectedAfter",
+        },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-attrs.test.js
@@ -133,6 +133,21 @@ ruleTester.run("no-extra-spacing-attrs", rule, {
         },
       ],
     },
+    {
+      code: `
+\t<div>
+\t\t<img src="foo" />
+\t\t<div foo="bar"></div>
+\t</div>
+`,
+      options: [
+        {
+          disallowMissing: true,
+          disallowTabs: true,
+          enforceBeforeSelfClose: true
+        }
+      ]
+    }
   ],
   invalid: [
     {


### PR DESCRIPTION
This adds two things to `no-extra-spacing-attrs`:

- It adds a `disallowTabs` option to enforce using only spaces inside a tag
- It checks for extra spaces between the tag start and the tag end, whereas the current version only checks for extra spaces before the tag end if the tag has attributes or is self-closing

Because this rule can now have an effect when a tag has no attributes, in the future may want to rename the rule to just `no-extra-spacing`... Just a thought!

Thanks! :)