### PR TITLE
feat: adds `inline` option to element-newline; fixes #210

### DIFF
--- a/docs/rules/element-newline.md
+++ b/docs/rules/element-newline.md
@@ -37,7 +37,8 @@ Examples of **correct** code for this rule:
 
 This rule has an object option:
 
-- `"skip"`: skips newline checking for the specified element's children.
+- `"skip"`: skips newline checking for the specified elements` children.
+- `"inline"`: instructs the linter that the specified elements can remain on the same line.
 
 ```ts
 //...
@@ -66,3 +67,20 @@ Examples of **correct** code for the `{ "skip": ["pre", "code"] }` option:
     <span></span><div></div>
 </code>
 ```
+
+#### inline
+
+You can specify list of tag names in the `inline` option.
+Newlines are not enforced between the specified tags.
+As a shortcut, if you include the special value `$inline` in the list then all HTML tags that are usually inline (<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element#inline_text_semantics">as defined by Mozilla</a>) will be included.
+
+Examples of **correct** code for the `{ "inline": ["$inline"] }` option:
+
+<!-- prettier-ignore -->
+```html
+<div>
+    I <strong>like</strong> these <dfn>inline</dfn> tags.
+    <p>It's <em>true</em>!</p>
+</div>
+```
+

--- a/docs/rules/element-newline.md
+++ b/docs/rules/element-newline.md
@@ -83,4 +83,3 @@ Examples of **correct** code for the `{ "inline": ["$inline"] }` option:
     <p>It's <em>true</em>!</p>
 </div>
 ```
-

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -7,7 +7,12 @@ module.exports = {
     "@html-eslint/no-multiple-h1": "error",
     "@html-eslint/no-extra-spacing-attrs": "error",
     "@html-eslint/attrs-newline": "error",
-    "@html-eslint/element-newline": "error",
+    "@html-eslint/element-newline": [
+      "error",
+      {
+        inline: [`$inline`],
+      },
+    ],
     "@html-eslint/no-duplicate-id": "error",
     "@html-eslint/indent": "error",
     "@html-eslint/require-li-container": "error",

--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -288,6 +288,7 @@ module.exports = {
 
     return {
       Program(node) {
+        // @ts-ignore
         checkSiblings(node.body);
       },
     };

--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -29,6 +29,39 @@ const MESSAGE_IDS = {
  * @type {Object.<string, Array<string>>}
  */
 const PRESETS = {
+  // From https://developer.mozilla.org/en-US/docs/Web/HTML/Element#inline_text_semantics
+  $inline: `
+a
+abbr
+b
+bdi
+bdo
+br
+cite
+code
+data
+dfn
+em
+i
+kbd
+mark
+q
+rp
+rt
+ruby
+s
+samp
+small
+span
+strong
+sub
+sup
+time
+u
+var
+wbr
+  `.trim().split(`\n`),
+
   $pre: `
 code
 pre
@@ -53,6 +86,13 @@ module.exports = {
       {
         type: "object",
         properties: {
+          inline: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+
           skip: {
             type: "array",
             items: {
@@ -77,6 +117,7 @@ module.exports = {
   create(context) {
     const option = context.options[0] || {};
     const skipTags = optionsOrPresets(option.skip || []);
+    const inlineTags = optionsOrPresets(option.inline || []);
 
     /**
      * @param {Array<NewlineNode>} siblings
@@ -236,6 +277,8 @@ module.exports = {
       switch (node.type) {
         case `Comment`:
           return /[\n\r]+/.test(node.value.value.trim());
+        case `Tag`:
+          return inlineTags.includes(node.name.toLowerCase()) === false;
         case `Text`:
           return /[\n\r]+/.test(node.value.trim());
         default:

--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -251,7 +251,7 @@ module.exports = {
           }
           return `<${node.name}>`;
         default:
-          return `<${node.type}>`; // TODO1
+          return `<${node.type}>`;
       }
     }
 

--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -60,8 +60,10 @@ time
 u
 var
 wbr
-  `.trim().split(`\n`),
-}
+  `
+    .trim()
+    .split(`\n`),
+};
 
 /**
  * @type {RuleModule}
@@ -129,7 +131,11 @@ module.exports = {
       };
 
       const nodesWithContent = [];
-      for (let length = siblings.length, index = 0; index < length; index += 1) {
+      for (
+        let length = siblings.length, index = 0;
+        index < length;
+        index += 1
+      ) {
         const node = siblings[index];
 
         if (isEmptyText(node) === false) {
@@ -137,7 +143,11 @@ module.exports = {
         }
       }
 
-      for (let length = nodesWithContent.length, index = 0; index < length; index += 1) {
+      for (
+        let length = nodesWithContent.length, index = 0;
+        index < length;
+        index += 1
+      ) {
         const node = nodesWithContent[index];
         const nodeNext = nodesWithContent[index + 1];
 
@@ -158,12 +168,14 @@ module.exports = {
           }
 
           if (
-            nodeShouldBeNewline
-            && nodeChildShouldBeNewline
-            && nodeMeta.childFirst
-            && nodeMeta.childLast
+            nodeShouldBeNewline &&
+            nodeChildShouldBeNewline &&
+            nodeMeta.childFirst &&
+            nodeMeta.childLast
           ) {
-            if (node.openEnd.loc.end.line === nodeMeta.childFirst.loc.start.line) {
+            if (
+              node.openEnd.loc.end.line === nodeMeta.childFirst.loc.start.line
+            ) {
               const child = nodeMeta.childFirst;
               if (child.type !== `Text` || /^\n/.test(child.value) === false) {
                 context.report({
@@ -190,10 +202,7 @@ module.exports = {
           }
         }
 
-        if (
-          nodeNext
-          && node.loc.end.line === nodeNext.loc.start.line
-        ) {
+        if (nodeNext && node.loc.end.line === nodeNext.loc.start.line) {
           if (nodeShouldBeNewline) {
             context.report({
               node: nodeNext,
@@ -225,7 +234,7 @@ module.exports = {
      * @param {NewlineNode} node
      */
     function isEmptyText(node) {
-      return (node.type === `Text` && node.value.trim().length === 0);
+      return node.type === `Text` && node.value.trim().length === 0;
     }
 
     /**
@@ -261,7 +270,6 @@ module.exports = {
       }
       return result;
     }
-
 
     /**
      * @param {NewlineNode} node

--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -26,6 +26,16 @@ const MESSAGE_IDS = {
 };
 
 /**
+ * @type {Object.<string, Array<string>>}
+ */
+const PRESETS = {
+  $pre: `
+code
+pre
+  `.trim().split(`\n`),
+}
+
+/**
  * @type {RuleModule}
  */
 module.exports = {
@@ -65,8 +75,9 @@ module.exports = {
   },
 
   create(context) {
-    const option = context.options[0] || { skip: [] };
-    const skipTags = option.skip;
+    const option = context.options[0] || {};
+    const skipTags = optionsOrPresets(option.skip || []);
+
     /**
      * @param {Array<NewlineNode>} siblings
      * @returns {NodeMeta} meta
@@ -165,6 +176,13 @@ module.exports = {
     /**
      * @param {NewlineNode} node
      */
+    function isEmptyText(node) {
+      return (node.type === `Text` && node.value.trim().length === 0);
+    }
+
+    /**
+     * @param {NewlineNode} node
+     */
     function isInline(node) {
       switch (node.type) {
         case `Comment`:
@@ -183,13 +201,6 @@ module.exports = {
      */
     function isNewline(node) {
       return (isInline(node) === false);
-    }
-
-    /**
-     * @param {NewlineNode} node
-     */
-    function isEmptyText(node) {
-      return (node.type === `Text` && node.value.trim().length === 0);
     }
 
     /**
@@ -215,6 +226,22 @@ module.exports = {
      */
     function mayHaveChildren(node) {
       return (node.type === `Tag`);
+    }
+
+    /**
+     * @param {Array<string>} options
+     */
+    function optionsOrPresets(options) {
+      const result = [];
+      for (const option of options) {
+        if (option in PRESETS) {
+          const preset = PRESETS[option];
+          result.push(...preset);
+        } else {
+          result.push(option);
+        }
+      }
+      return result;
     }
 
     return {

--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -105,19 +105,19 @@ module.exports = {
 
         meta.childLast = node;
 
-        const nodeIsNewline = isNewline(node);
+        const nodeShouldBeNewline = shouldBeNewline(node);
 
         if (mayHaveChildren(node) && skipTags.includes(node.name) === false) {
           const nodeMeta = checkSiblings(node.children);
-          const nodeContainsNewline = nodeMeta.containsNewline;
+          const nodeChildShouldBeNewline = nodeMeta.containsNewline;
 
-          if (nodeIsNewline || nodeContainsNewline) {
+          if (nodeShouldBeNewline || nodeChildShouldBeNewline) {
             meta.containsNewline = true;
           }
 
           if (
-            nodeIsNewline
-            && nodeContainsNewline
+            nodeShouldBeNewline
+            && nodeChildShouldBeNewline
             && nodeMeta.childFirst
             && nodeMeta.childLast
           ) {
@@ -148,7 +148,7 @@ module.exports = {
         const nodeNext = siblings[index + 1];
 
         if (nodeNext) {
-          if (nodeIsNewline && isEmptyText(nodeNext) === false) {
+          if (nodeShouldBeNewline && isEmptyText(nodeNext) === false) {
             context.report({
               node: nodeNext,
               messageId: MESSAGE_IDS.EXPECT_NEW_LINE_AFTER,
@@ -157,7 +157,7 @@ module.exports = {
                 return fixer.insertTextAfter(node, `\n`);
               },
             });
-          } else if (isNewline(nodeNext)) {
+          } else if (shouldBeNewline(nodeNext)) {
             context.report({
               node: nodeNext,
               messageId: MESSAGE_IDS.EXPECT_NEW_LINE_BEFORE,
@@ -178,29 +178,6 @@ module.exports = {
      */
     function isEmptyText(node) {
       return (node.type === `Text` && node.value.trim().length === 0);
-    }
-
-    /**
-     * @param {NewlineNode} node
-     */
-    function isInline(node) {
-      switch (node.type) {
-        case `Comment`:
-          return node.value.value.trim().match(/\n|\r/) === null;
-        // case `Tag`:
-        //   return skipTags.includes(node.name);
-        case `Text`:
-          return node.value.trim().match(/\n|\r/) === null;
-        default:
-          return false;
-      }
-    }
-
-    /**
-     * @param {NewlineNode} node
-     */
-    function isNewline(node) {
-      return (isInline(node) === false);
     }
 
     /**
@@ -242,6 +219,21 @@ module.exports = {
         }
       }
       return result;
+    }
+
+
+    /**
+     * @param {NewlineNode} node
+     */
+    function shouldBeNewline(node) {
+      switch (node.type) {
+        case `Comment`:
+          return /[\n\r]+/.test(node.value.value.trim());
+        case `Text`:
+          return /[\n\r]+/.test(node.value.trim());
+        default:
+          return true;
+      }
     }
 
     return {

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -141,6 +141,36 @@ ruleTester.run("element-newline", rule, {
         },
       ],
     },
+    {
+      code: `
+        <h1 class="display1 md:text-[60px] md:leading-[68px] md:font-bold">
+            An <span class="text-accent">ESLint</span>
+            <br class="md:hidden">
+            plugin<br>
+            to lint and fix <span class="text-accent">HTML code</span>.
+        </h1>
+`,
+      options: [
+        {
+          inline: [`$inline`],
+        },
+      ],
+    },
+    {
+      code: `
+      <header>
+        <img
+            foo="bar"
+        >
+        html-eslint
+      </header>
+      `,
+      options: [
+        {
+          inline: [`$inline`],
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -22,7 +22,7 @@ ruleTester.run("element-newline", rule, {
       <html lang="en">
           <body>
               <ul>
-                  <li>Item Here
+                  <li>Item Here</li>
                   <li>Second Item Here</li>
               </ul>
           </body>
@@ -40,7 +40,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["pre", "code"],
+          skip: ["pre", "code", "div"],
         },
       ],
     },
@@ -52,7 +52,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["div"],
+          skip: ["a"],
         },
       ],
     },
@@ -66,7 +66,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["div"],
+          skip: ["a"],
         },
       ],
     },
@@ -78,7 +78,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["div"],
+          skip: ["div", "span", "a"],
         },
       ],
     },
@@ -86,10 +86,47 @@ ruleTester.run("element-newline", rule, {
       code: `<pre><div></div><code><span></span></code><a></a></pre>`,
       options: [
         {
-          skip: ["pre", "code"],
+          skip: ["pre", "code", "div", "span", "a"],
         },
       ],
     },
+    {
+      code: `
+<a>
+<b></b>
+<c></c>
+</a>
+`,
+    },
+    {
+      code: `
+<a><b></b>
+<c></c></a>
+`,
+      options: [
+        {
+          skip: ["a"]
+        }
+      ]
+    },
+    {
+      code: `<a><b></b><c></c></a>`,
+      options: [
+        {
+          skip: ["b", "c"]
+        }
+      ]
+    },
+    {
+      code: `<a>
+<b></b><c></c>
+</a>`,
+      options: [
+        {
+          skip: ["b", "c"]
+        }
+      ]
+    }
   ],
   invalid: [
     {
@@ -122,7 +159,7 @@ ruleTester.run("element-newline", rule, {
           messageId: "expectAfter",
         },
         {
-          messageId: "expectAfter",
+          messageId: "expectBefore",
         },
       ],
     },
@@ -139,10 +176,10 @@ ruleTester.run("element-newline", rule, {
 
       errors: [
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
         },
         {
-          messageId: "expectAfter",
+          messageId: "expectBeforeClose",
         },
         {
           messageId: "expectBefore",
@@ -163,16 +200,16 @@ ruleTester.run("element-newline", rule, {
 
       errors: [
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
         },
         {
-          messageId: "expectAfter",
+          messageId: "expectBeforeClose",
         },
         {
-          messageId: "expectBefore",
+          messageId: "expectAfterOpen",
         },
         {
-          messageId: "expectBefore",
+          messageId: "expectBeforeClose",
         },
       ],
     },
@@ -188,10 +225,10 @@ ruleTester.run("element-newline", rule, {
 
       errors: [
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
         },
         {
-          messageId: "expectBefore",
+          messageId: "expectBeforeClose",
         },
       ],
     },
@@ -207,10 +244,10 @@ ruleTester.run("element-newline", rule, {
 
       errors: [
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
         },
         {
-          messageId: "expectBefore",
+          messageId: "expectBeforeClose",
         },
       ],
     },
@@ -229,19 +266,19 @@ ruleTester.run("element-newline", rule, {
 
       errors: [
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
+        },
+        {
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
         },
         {
           messageId: "expectAfter",
-        },
-        {
-          messageId: "expectAfter",
-        },
-        {
-          messageId: "expectBefore",
-        },
-        {
-          messageId: "expectBefore",
         },
       ],
     },
@@ -261,22 +298,22 @@ ruleTester.run("element-newline", rule, {
 
       errors: [
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
+        },
+        {
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
         },
         {
           messageId: "expectAfter",
         },
         {
           messageId: "expectAfter",
-        },
-        {
-          messageId: "expectAfter",
-        },
-        {
-          messageId: "expectBefore",
-        },
-        {
-          messageId: "expectBefore",
         },
       ],
     },
@@ -298,28 +335,28 @@ ruleTester.run("element-newline", rule, {
 
       errors: [
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
+        },
+        {
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
         },
         {
           messageId: "expectAfter",
         },
         {
-          messageId: "expectAfter",
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
         },
         {
           messageId: "expectAfter",
-        },
-        {
-          messageId: "expectAfter",
-        },
-        {
-          messageId: "expectBefore",
-        },
-        {
-          messageId: "expectBefore",
-        },
-        {
-          messageId: "expectBefore",
         },
       ],
     },
@@ -329,7 +366,7 @@ ruleTester.run("element-newline", rule, {
 <code><div></div></code>`,
       options: [
         {
-          skip: ["pre", "code"],
+          skip: ["div"],
         },
       ],
       errors: [
@@ -350,7 +387,9 @@ ruleTester.run("element-newline", rule, {
 <span></span>
 <a></a>
 <div>
-<span><a></a></span>
+<span>
+<a></a>
+</span>
 </div>
 <span></span>
 <a></a>
@@ -363,6 +402,12 @@ ruleTester.run("element-newline", rule, {
       errors: [
         {
           messageId: "expectAfter",
+        },
+        {
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
         },
         {
           messageId: "expectAfter",
@@ -378,7 +423,9 @@ ruleTester.run("element-newline", rule, {
       output: `
 <span></span>
 <div>
-<span><a></a></span>
+<span>
+<a></a>
+</span>
 </div>
 `,
       options: [
@@ -390,7 +437,23 @@ ruleTester.run("element-newline", rule, {
         {
           messageId: "expectAfter",
         },
+        {
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
+        },
       ],
+    },
+    {
+      code: `<div></div><div></div>`,
+      output: `<div></div>
+<div></div>`,
+      errors: [
+        {
+          messageId: "expectAfter"
+        }
+      ]
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -40,7 +40,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["pre", "code", "div"],
+          skip: ["pre", "code"],
         },
       ],
     },
@@ -52,7 +52,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["a"],
+          skip: ["div"],
         },
       ],
     },
@@ -66,7 +66,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["a"],
+          skip: ["div"],
         },
       ],
     },
@@ -78,7 +78,7 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: ["div", "span", "a"],
+          skip: ["div"],
         },
       ],
     },
@@ -86,47 +86,10 @@ ruleTester.run("element-newline", rule, {
       code: `<pre><div></div><code><span></span></code><a></a></pre>`,
       options: [
         {
-          skip: ["pre", "code", "div", "span", "a"],
+          skip: ["pre", "code"],
         },
       ],
     },
-    {
-      code: `
-<a>
-<b></b>
-<c></c>
-</a>
-`,
-    },
-    {
-      code: `
-<a><b></b>
-<c></c></a>
-`,
-      options: [
-        {
-          skip: ["a"]
-        }
-      ]
-    },
-    {
-      code: `<a><b></b><c></c></a>`,
-      options: [
-        {
-          skip: ["b", "c"]
-        }
-      ]
-    },
-    {
-      code: `<a>
-<b></b><c></c>
-</a>`,
-      options: [
-        {
-          skip: ["b", "c"]
-        }
-      ]
-    }
   ],
   invalid: [
     {
@@ -366,7 +329,7 @@ ruleTester.run("element-newline", rule, {
 <code><div></div></code>`,
       options: [
         {
-          skip: ["div"],
+          skip: ["pre", "code"],
         },
       ],
       errors: [
@@ -387,9 +350,7 @@ ruleTester.run("element-newline", rule, {
 <span></span>
 <a></a>
 <div>
-<span>
-<a></a>
-</span>
+<span><a></a></span>
 </div>
 <span></span>
 <a></a>
@@ -402,12 +363,6 @@ ruleTester.run("element-newline", rule, {
       errors: [
         {
           messageId: "expectAfter",
-        },
-        {
-          messageId: "expectAfterOpen",
-        },
-        {
-          messageId: "expectBeforeClose",
         },
         {
           messageId: "expectAfter",
@@ -423,9 +378,7 @@ ruleTester.run("element-newline", rule, {
       output: `
 <span></span>
 <div>
-<span>
-<a></a>
-</span>
+<span><a></a></span>
 </div>
 `,
       options: [
@@ -437,23 +390,7 @@ ruleTester.run("element-newline", rule, {
         {
           messageId: "expectAfter",
         },
-        {
-          messageId: "expectAfterOpen",
-        },
-        {
-          messageId: "expectBeforeClose",
-        },
       ],
-    },
-    {
-      code: `<div></div><div></div>`,
-      output: `<div></div>
-<div></div>`,
-      errors: [
-        {
-          messageId: "expectAfter"
-        }
-      ]
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -46,22 +46,6 @@ ruleTester.run("element-newline", rule, {
     },
     {
       code: `
-<html>
-<body>
-      <pre><div></div></pre>
-      <code>
-      <div></div></code>
-</body>
-</html>
-`,
-      options: [
-        {
-          skip: ["$pre"],
-        },
-      ],
-    },
-    {
-      code: `
 <div>
 <span><a></a></span>
 </div>
@@ -137,6 +121,19 @@ ruleTester.run("element-newline", rule, {
     {
       code: `
 <a></a><abbr></abbr><b></b><bdi></bdi><bdo></bdo><br></br><cite></cite><code></code><data></data><dfn></dfn><em></em><i></i><kbd></kbd><mark></mark><q></q><rp></rp><rt></rt><ruby></ruby><s></s><samp></samp><small></small><span></span><strong></strong><sub></sub><sup></sup><time></time><u></u><var></var><wbr></wbr>
+`,
+      options: [
+        {
+          inline: [`$inline`],
+        },
+      ],
+    },
+    {
+      code: `
+<div>
+    I <strong>like</strong> these <dfn>inline</dfn> tags.
+    <p>It's <em>true</em>!</p>
+</div>
 `,
       options: [
         {
@@ -412,21 +409,6 @@ foo
       ],
     },
     {
-      code: `<pre><div></div></pre><code><div></div></code>`,
-      output: `<pre><div></div></pre>
-<code><div></div></code>`,
-      options: [
-        {
-          skip: ["$pre"],
-        },
-      ],
-      errors: [
-        {
-          messageId: "expectAfter",
-        },
-      ],
-    },
-    {
       code: `
 <span></span><a></a>
 <div>
@@ -495,6 +477,33 @@ foo
         },
         {
           messageId: "expectAfter",
+        },
+      ],
+      options: [
+        {
+          inline: [`$inline`],
+        },
+      ],
+    },
+    {
+      code: `
+<div>aaa<strong>bbb</strong><a>ccc</a><p>ddd<i>eee</i></p></div>
+`,
+      output: `
+<div>
+aaa<strong>bbb</strong><a>ccc</a>
+<p>ddd<i>eee</i></p>
+</div>
+`,
+      errors: [
+        {
+          messageId: "expectAfterOpen",
+        },
+        {
+          messageId: "expectBeforeClose",
+        },
+        {
+          messageId: "expectBefore",
         },
       ],
       options: [

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -125,6 +125,25 @@ ruleTester.run("element-newline", rule, {
     },
     {
       code: `
+<!DOCTYPE html>foo<html></html>
+`,
+      output: `
+<!DOCTYPE html>
+foo
+<html></html>
+`,
+
+      errors: [
+        {
+          messageId: "expectAfter",
+        },
+        {
+          messageId: "expectBefore",
+        },
+      ],
+    },
+    {
+      code: `
 <!DOCTYPE html><!-- comment --><html></html>
 `,
       output: `

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -100,9 +100,9 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          inline: [`d`]
-        }
-      ]
+          inline: [`d`],
+        },
+      ],
     },
     {
       code: `
@@ -114,9 +114,9 @@ ruleTester.run("element-newline", rule, {
 `,
       options: [
         {
-          skip: [`c`]
-        }
-      ]
+          skip: [`c`],
+        },
+      ],
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -46,6 +46,22 @@ ruleTester.run("element-newline", rule, {
     },
     {
       code: `
+<html>
+<body>
+      <pre><div></div></pre>
+      <code>
+      <div></div></code>
+</body>
+</html>
+`,
+      options: [
+        {
+          skip: ["$pre"],
+        },
+      ],
+    },
+    {
+      code: `
 <div>
 <span><a></a></span>
 </div>
@@ -330,6 +346,21 @@ ruleTester.run("element-newline", rule, {
       options: [
         {
           skip: ["pre", "code"],
+        },
+      ],
+      errors: [
+        {
+          messageId: "expectAfter",
+        },
+      ],
+    },
+    {
+      code: `<pre><div></div></pre><code><div></div></code>`,
+      output: `<pre><div></div></pre>
+<code><div></div></code>`,
+      options: [
+        {
+          skip: ["$pre"],
         },
       ],
       errors: [

--- a/packages/eslint-plugin/tests/rules/element-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/element-newline.test.js
@@ -106,6 +106,44 @@ ruleTester.run("element-newline", rule, {
         },
       ],
     },
+    {
+      code: `
+<a>
+  <b>
+    <c><d></d></c>
+  </b>
+</a>
+`,
+      options: [
+        {
+          inline: [`d`]
+        }
+      ]
+    },
+    {
+      code: `
+<a>
+  <b>
+    <c><d></d></c>
+  </b>
+</a>
+`,
+      options: [
+        {
+          skip: [`c`]
+        }
+      ]
+    },
+    {
+      code: `
+<a></a><abbr></abbr><b></b><bdi></bdi><bdo></bdo><br></br><cite></cite><code></code><data></data><dfn></dfn><em></em><i></i><kbd></kbd><mark></mark><q></q><rp></rp><rt></rt><ruby></ruby><s></s><samp></samp><small></small><span></span><strong></strong><sub></sub><sup></sup><time></time><u></u><var></var><wbr></wbr>
+`,
+      options: [
+        {
+          inline: [`$inline`],
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -439,6 +477,29 @@ foo
       errors: [
         {
           messageId: "expectAfter",
+        },
+      ],
+    },
+    {
+      code: `
+<a></a><abbr></abbr><b></b><bdi></bdi><bdo></bdo><br></br><cite></cite><code></code><div></div><data></data><dfn></dfn><em></em><i></i><kbd></kbd><mark></mark><q></q><rp></rp><rt></rt><ruby></ruby><s></s><samp></samp><small></small><span></span><strong></strong><sub></sub><sup></sup><time></time><u></u><var></var><wbr></wbr>
+`,
+      output: `
+<a></a><abbr></abbr><b></b><bdi></bdi><bdo></bdo><br></br><cite></cite><code></code>
+<div></div>
+<data></data><dfn></dfn><em></em><i></i><kbd></kbd><mark></mark><q></q><rp></rp><rt></rt><ruby></ruby><s></s><samp></samp><small></small><span></span><strong></strong><sub></sub><sup></sup><time></time><u></u><var></var><wbr></wbr>
+`,
+      errors: [
+        {
+          messageId: "expectBefore",
+        },
+        {
+          messageId: "expectAfter",
+        },
+      ],
+      options: [
+        {
+          inline: [`$inline`],
         },
       ],
     },

--- a/packages/website/src/components/header/header.html
+++ b/packages/website/src/components/header/header.html
@@ -29,7 +29,8 @@
             class="inline w-[21px] mr-[11px]"
             width="21"
             height="24"
-        >html-eslint
+        >
+        html-eslint
     </a>
     <span class="body8 inline-block bg-gray-200 text-black-500 rounded-[12px] px-[8px] py-[5px] mx-[8px]">
         v{{ version }}


### PR DESCRIPTION
- Adds additional error messages to `element-newline`, so that it specifies whether a space is needed between a tag and its content or between two sibling elements
- Adds an `inline` option to `element-newline`, indicating that the specified elements can be on the same line when they are siblings