### PR TITLE
feat: support linting html in template literals

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-accesskey-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-accesskey-attrs.js
@@ -7,6 +7,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   UNEXPECTED: "unexpected",
@@ -33,19 +34,22 @@ module.exports = {
   },
 
   create(context) {
-    return {
-      /**
-       * @param {TagNode | ScriptTagNode | StyleTagNode} node
-       */
-      [["Tag", "ScriptTag", "StyleTag"].join(",")](node) {
-        const accessKeyAttr = findAttr(node, "accesskey");
-        if (accessKeyAttr) {
-          context.report({
-            node: accessKeyAttr,
-            messageId: MESSAGE_IDS.UNEXPECTED,
-          });
-        }
-      },
-    };
+    /**
+     * @param {TagNode | ScriptTagNode | StyleTagNode} node
+     */
+    function check(node) {
+      const accessKeyAttr = findAttr(node, "accesskey");
+      if (accessKeyAttr) {
+        context.report({
+          node: accessKeyAttr,
+          messageId: MESSAGE_IDS.UNEXPECTED,
+        });
+      }
+    }
+    return createVisitors(context, {
+      Tag: check,
+      ScriptTag: check,
+      StyleTag: check,
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/no-aria-hidden-body.js
+++ b/packages/eslint-plugin/lib/rules/no-aria-hidden-body.js
@@ -4,6 +4,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   UNEXPECTED: "unexpected",
@@ -31,24 +32,29 @@ module.exports = {
   },
 
   create(context) {
-    return {
+    return createVisitors(context, {
       Tag(node) {
         if (node.name !== "body") {
           return;
         }
         const ariaHiddenAttr = findAttr(node, "aria-hidden");
-        if (ariaHiddenAttr) {
-          if (
-            (ariaHiddenAttr.value && ariaHiddenAttr.value.value !== "false") ||
-            !ariaHiddenAttr.value
-          ) {
-            context.report({
-              node: ariaHiddenAttr,
-              messageId: MESSAGE_IDS.UNEXPECTED,
-            });
-          }
+        if (!ariaHiddenAttr) {
+          return;
+        }
+        if (ariaHiddenAttr.value && ariaHiddenAttr.value.templates.length) {
+          return;
+        }
+
+        if (
+          (ariaHiddenAttr.value && ariaHiddenAttr.value.value !== "false") ||
+          !ariaHiddenAttr.value
+        ) {
+          context.report({
+            node: ariaHiddenAttr,
+            messageId: MESSAGE_IDS.UNEXPECTED,
+          });
         }
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/no-duplicate-id.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-id.js
@@ -3,10 +3,17 @@
  * @typedef { import("../types").TagNode } TagNode
  * @typedef { import("../types").StyleTagNode } StyleTagNode
  * @typedef { import("../types").ScriptTagNode } ScriptTagNode
+ * @typedef { import("es-html-parser").AttributeValueNode } AttributeValueNode
  */
 
+const { parse } = require("@html-eslint/template-parser");
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const {
+  shouldCheckTaggedTemplateExpression,
+  shouldCheckTemplateLiteral,
+} = require("./utils/settings");
+const { getSourceCode } = require("./utils/source-code");
 
 const MESSAGE_IDS = {
   DUPLICATE_ID: "duplicateId",
@@ -33,37 +40,71 @@ module.exports = {
   },
 
   create(context) {
-    const IdAttrsMap = new Map();
-    return {
+    const htmlIdAttrsMap = new Map();
+    /**
+     * @param {Map<string, AttributeValueNode[]>} map
+     */
+    function createTagVisitor(map) {
       /**
-       * @param {TagNode | ScriptTagNode | StyleTagNode} node
-       * @returns
+       * @param {TagNode} node
        */
-      Tag(node) {
+      return function (node) {
         if (!node.attributes || node.attributes.length <= 0) {
           return;
         }
         const idAttr = findAttr(node, "id");
         if (idAttr && idAttr.value) {
-          if (!IdAttrsMap.has(idAttr.value.value)) {
-            IdAttrsMap.set(idAttr.value.value, []);
+          if (!map.has(idAttr.value.value)) {
+            map.set(idAttr.value.value, []);
           }
-          const nodes = IdAttrsMap.get(idAttr.value.value);
-          nodes.push(idAttr.value);
+          const nodes = map.get(idAttr.value.value);
+          if (nodes) {
+            nodes.push(idAttr.value);
+          }
         }
-      },
-      "Program:exit"() {
-        IdAttrsMap.forEach((attrs) => {
-          if (Array.isArray(attrs) && attrs.length > 1) {
-            attrs.forEach((attr) => {
-              context.report({
-                node: attr,
-                data: { id: attr.value },
-                messageId: MESSAGE_IDS.DUPLICATE_ID,
-              });
+      };
+    }
+
+    /**
+     *
+     * @param {Map<string, AttributeValueNode[]>} map
+     */
+    function report(map) {
+      map.forEach((attrs) => {
+        if (Array.isArray(attrs) && attrs.length > 1) {
+          attrs.forEach((attr) => {
+            context.report({
+              node: attr,
+              data: { id: attr.value },
+              messageId: MESSAGE_IDS.DUPLICATE_ID,
             });
-          }
-        });
+          });
+        }
+      });
+    }
+
+    return {
+      Tag: createTagVisitor(htmlIdAttrsMap),
+      "Program:exit"() {
+        report(htmlIdAttrsMap);
+      },
+      TaggedTemplateExpression(node) {
+        const idAttrsMap = new Map();
+        if (shouldCheckTaggedTemplateExpression(node, context)) {
+          parse(node.quasi, getSourceCode(context), {
+            Tag: createTagVisitor(idAttrsMap),
+          });
+        }
+        report(idAttrsMap);
+      },
+      TemplateLiteral(node) {
+        const idAttrsMap = new Map();
+        if (shouldCheckTemplateLiteral(node, context)) {
+          parse(node, getSourceCode(context), {
+            Tag: createTagVisitor(idAttrsMap),
+          });
+        }
+        report(idAttrsMap);
       },
     };
   },

--- a/packages/eslint-plugin/lib/rules/no-positive-tabindex.js
+++ b/packages/eslint-plugin/lib/rules/no-positive-tabindex.js
@@ -7,6 +7,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   UNEXPECTED: "unexpected",
@@ -33,23 +34,28 @@ module.exports = {
   },
 
   create(context) {
-    return {
-      /**
-       * @param {TagNode | StyleTagNode | ScriptTagNode} node
-       */
-      [["Tag", "StyleTag", "ScriptTag"].join(",")](node) {
-        const tabIndexAttr = findAttr(node, "tabindex");
-        if (
-          tabIndexAttr &&
-          tabIndexAttr.value &&
-          parseInt(tabIndexAttr.value.value, 10) > 0
-        ) {
-          context.report({
-            node: tabIndexAttr,
-            messageId: MESSAGE_IDS.UNEXPECTED,
-          });
-        }
-      },
-    };
+    /**
+     * @param {TagNode | StyleTagNode | ScriptTagNode} node
+     */
+    function check(node) {
+      const tabIndexAttr = findAttr(node, "tabindex");
+      if (
+        tabIndexAttr &&
+        tabIndexAttr.value &&
+        !tabIndexAttr.value.templates.length &&
+        parseInt(tabIndexAttr.value.value, 10) > 0
+      ) {
+        context.report({
+          node: tabIndexAttr,
+          messageId: MESSAGE_IDS.UNEXPECTED,
+        });
+      }
+    }
+
+    return createVisitors(context, {
+      Tag: check,
+      StyleTag: check,
+      ScriptTag: check,
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/no-restricted-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-restricted-attrs.js
@@ -9,6 +9,7 @@
 
 const { NODE_TYPES } = require("@html-eslint/parser");
 const { RULE_CATEGORY } = require("../constants");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   RESTRICTED: "restricted",
@@ -65,52 +66,56 @@ module.exports = {
     const options = context.options;
     const checkers = options.map((option) => new PatternChecker(option));
 
-    return {
-      /**
-       * @param {TagNode | StyleTagNode | ScriptTagNode} node
-       */
-      [["Tag", "StyleTag", "ScriptTag"].join(",")](node) {
-        const tagName =
-          node.type === NODE_TYPES.Tag
-            ? node.name
-            : node.type === NODE_TYPES.ScriptTag
+    /**
+     * @param {TagNode | StyleTagNode | ScriptTagNode} node
+     */
+    function check(node) {
+      const tagName =
+        node.type === NODE_TYPES.Tag
+          ? node.name
+          : node.type === NODE_TYPES.ScriptTag
             ? "script"
             : "style";
-        node.attributes.forEach((attr) => {
-          if (!attr.key || !attr.key.value) {
-            return;
-          }
-          const matched = checkers.find((checker) =>
-            checker.test(tagName, attr.key.value)
-          );
+      node.attributes.forEach((attr) => {
+        if (!attr.key || !attr.key.value) {
+          return;
+        }
+        const matched = checkers.find((checker) =>
+          checker.test(tagName, attr.key.value)
+        );
 
-          if (!matched) {
-            return;
-          }
+        if (!matched) {
+          return;
+        }
 
-          /**
-           * @type {{node: AttributeNode, message: string, messageId?: string}}
-           */
-          const result = {
-            node: attr,
-            message: "",
-          };
+        /**
+         * @type {{node: AttributeNode, message: string, messageId?: string}}
+         */
+        const result = {
+          node: attr,
+          message: "",
+        };
 
-          const customMessage = matched.getMessage();
+        const customMessage = matched.getMessage();
 
-          if (customMessage) {
-            result.message = customMessage;
-          } else {
-            result.messageId = MESSAGE_IDS.RESTRICTED;
-          }
+        if (customMessage) {
+          result.message = customMessage;
+        } else {
+          result.messageId = MESSAGE_IDS.RESTRICTED;
+        }
 
-          context.report({
-            ...result,
-            data: { attr: attr.key.value },
-          });
+        context.report({
+          ...result,
+          data: { attr: attr.key.value },
         });
-      },
-    };
+      });
+    }
+
+    return createVisitors(context, {
+      Tag: check,
+      StyleTag: check,
+      ScriptTag: check,
+    });
   },
 };
 

--- a/packages/eslint-plugin/lib/rules/no-restricted-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-restricted-attrs.js
@@ -74,8 +74,8 @@ module.exports = {
         node.type === NODE_TYPES.Tag
           ? node.name
           : node.type === NODE_TYPES.ScriptTag
-            ? "script"
-            : "style";
+          ? "script"
+          : "style";
       node.attributes.forEach((attr) => {
         if (!attr.key || !attr.key.value) {
           return;

--- a/packages/eslint-plugin/lib/rules/no-script-style-type.js
+++ b/packages/eslint-plugin/lib/rules/no-script-style-type.js
@@ -7,6 +7,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   UNNECESSARY: "unnecessary",
@@ -56,7 +57,7 @@ module.exports = {
         });
       }
     }
-    return {
+    return createVisitors(context, {
       ScriptTag(node) {
         check(node, "text/javascript");
       },
@@ -71,6 +72,6 @@ module.exports = {
           }
         }
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/no-target-blank.js
+++ b/packages/eslint-plugin/lib/rules/no-target-blank.js
@@ -4,6 +4,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   MISSING: "missing",
@@ -38,7 +39,7 @@ module.exports = {
     function isExternalLink(link) {
       return /^(?:\w+:|\/\/)/.test(link);
     }
-    return {
+    return createVisitors(context, {
       Tag(node) {
         if (node.name !== "a") {
           return;
@@ -49,6 +50,10 @@ module.exports = {
           const href = findAttr(node, "href");
           if (href && href.value && isExternalLink(href.value.value)) {
             const rel = findAttr(node, "rel");
+            if (rel && rel.value && rel.value.templates.length) {
+              return;
+            }
+
             if (!rel || !rel.value || !rel.value.value.includes("noreferrer")) {
               context.report({
                 node: target,
@@ -58,6 +63,6 @@ module.exports = {
           }
         }
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/quotes.js
+++ b/packages/eslint-plugin/lib/rules/quotes.js
@@ -8,6 +8,7 @@
  */
 
 const { RULE_CATEGORY } = require("../constants");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   UNEXPECTED: "unexpected",
@@ -131,14 +132,17 @@ module.exports = {
         });
       }
     }
+    /**
+     * @param {TagNode | ScriptTagNode | StyleTagNode} node
+     */
+    function check(node) {
+      node.attributes.forEach((attr) => checkQuotes(attr));
+    }
 
-    return {
-      /**
-       * @param {TagNode | ScriptTagNode | StyleTagNode} node
-       */
-      [["Tag", "ScriptTag", "StyleTag"].join(",")](node) {
-        node.attributes.forEach((attr) => checkQuotes(attr));
-      },
-    };
+    return createVisitors(context, {
+      Tag: check,
+      ScriptTag: check,
+      StyleTag: check,
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/require-attrs.js
+++ b/packages/eslint-plugin/lib/rules/require-attrs.js
@@ -7,6 +7,7 @@
 
 const { NODE_TYPES } = require("@html-eslint/parser");
 const { RULE_CATEGORY } = require("../constants");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   MISSING: "missing",
@@ -103,25 +104,32 @@ module.exports = {
       });
     }
 
-    return {
-      /**
-       * @param {StyleTagNode | ScriptTagNode} node
-       * @returns
-       */
-      [["StyleTag", "ScriptTag"].join(",")](node) {
-        const tagName = node.type === NODE_TYPES.StyleTag ? "style" : "script";
-        if (!tagOptionsMap.has(tagName)) {
-          return;
-        }
-        check(node, tagName);
-      },
-      Tag(node) {
-        const tagName = node.name.toLowerCase();
-        if (!tagOptionsMap.has(tagName)) {
-          return;
-        }
-        check(node, tagName);
-      },
-    };
+    /**
+     * @param {StyleTagNode | ScriptTagNode} node
+     */
+    function checkStyleOrScript(node) {
+      const tagName = node.type === NODE_TYPES.StyleTag ? "style" : "script";
+      if (!tagOptionsMap.has(tagName)) {
+        return;
+      }
+      check(node, tagName);
+    }
+
+    /**
+     * @param {TagNode} node
+     */
+    function checkTag(node) {
+      const tagName = node.name.toLowerCase();
+      if (!tagOptionsMap.has(tagName)) {
+        return;
+      }
+      check(node, tagName);
+    }
+
+    return createVisitors(context, {
+      StyleTag: checkStyleOrScript,
+      ScriptTag: checkStyleOrScript,
+      Tag: checkTag,
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/require-button-type.js
+++ b/packages/eslint-plugin/lib/rules/require-button-type.js
@@ -47,7 +47,10 @@ module.exports = {
             node: node.openStart,
             messageId: MESSAGE_IDS.MISSING,
           });
-        } else if (!VALID_BUTTON_TYPES_SET.has(typeAttr.value.value)) {
+        } else if (
+          !VALID_BUTTON_TYPES_SET.has(typeAttr.value.value) &&
+          !typeAttr.value.templates.length
+        ) {
           context.report({
             node: typeAttr,
             messageId: MESSAGE_IDS.INVALID,

--- a/packages/eslint-plugin/lib/rules/require-button-type.js
+++ b/packages/eslint-plugin/lib/rules/require-button-type.js
@@ -4,6 +4,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   MISSING: "missing",
@@ -35,7 +36,7 @@ module.exports = {
   },
 
   create(context) {
-    return {
+    return createVisitors(context, {
       Tag(node) {
         if (node.name !== "button") {
           return;
@@ -56,6 +57,6 @@ module.exports = {
           });
         }
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/require-closing-tags.js
+++ b/packages/eslint-plugin/lib/rules/require-closing-tags.js
@@ -4,6 +4,7 @@
  */
 
 const { RULE_CATEGORY, VOID_ELEMENTS } = require("../constants");
+const { createVisitors } = require("./utils/visitors");
 
 const VOID_ELEMENTS_SET = new Set(VOID_ELEMENTS);
 
@@ -125,7 +126,7 @@ module.exports = {
       }
     }
 
-    return {
+    return createVisitors(context, {
       Tag(node) {
         const isVoidElement = VOID_ELEMENTS_SET.has(node.name);
         const isSelfClosingCustomElement = !!selfClosingCustomPatterns.some(
@@ -156,6 +157,6 @@ module.exports = {
           foreignContext.pop();
         }
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/require-frame-title.js
+++ b/packages/eslint-plugin/lib/rules/require-frame-title.js
@@ -4,6 +4,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   MISSING: "missing",
@@ -32,7 +33,7 @@ module.exports = {
   },
 
   create(context) {
-    return {
+    return createVisitors(context, {
       Tag(node) {
         if (node.name !== "frame" && node.name !== "iframe") {
           return;
@@ -51,6 +52,6 @@ module.exports = {
           });
         }
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/require-img-alt.js
+++ b/packages/eslint-plugin/lib/rules/require-img-alt.js
@@ -4,6 +4,7 @@
  */
 
 const { RULE_CATEGORY } = require("../constants");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   MISSING_ALT: "missingAlt",
@@ -48,7 +49,7 @@ module.exports = {
         context.options[0].substitute) ||
       [];
 
-    return {
+    return createVisitors(context, {
       Tag(node) {
         if (node.name !== "img") {
           return;
@@ -66,7 +67,7 @@ module.exports = {
           });
         }
       },
-    };
+    });
   },
 };
 

--- a/packages/eslint-plugin/lib/rules/require-lang.js
+++ b/packages/eslint-plugin/lib/rules/require-lang.js
@@ -4,6 +4,7 @@
 
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   MISSING: "missing",
@@ -32,7 +33,7 @@ module.exports = {
   },
 
   create(context) {
-    return {
+    return createVisitors(context, {
       Tag(node) {
         if (node.name !== "html") {
           return;
@@ -56,6 +57,6 @@ module.exports = {
           });
         }
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/sort-attrs.js
+++ b/packages/eslint-plugin/lib/rules/sort-attrs.js
@@ -6,6 +6,8 @@
  */
 
 const { RULE_CATEGORY } = require("../constants");
+const { getSourceCode } = require("./utils/source-code");
+const { createVisitors } = require("./utils/visitors");
 
 const MESSAGE_IDS = {
   UNSORTED: "unsorted",
@@ -43,7 +45,7 @@ module.exports = {
     },
   },
   create(context) {
-    const sourceCode = context.getSourceCode();
+    const sourceCode = getSourceCode(context);
     const option = context.options[0] || {
       priority: ["id", "type", "class", "style"],
     };
@@ -150,7 +152,7 @@ module.exports = {
       });
     }
 
-    return {
+    return createVisitors(context, {
       ScriptTag(node) {
         checkSorting(node.attributes);
       },
@@ -160,6 +162,6 @@ module.exports = {
       StyleTag(node) {
         checkSorting(node.attributes);
       },
-    };
+    });
   },
 };

--- a/packages/eslint-plugin/tests/rules/no-accesskey-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-accesskey-attrs.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-accesskey-attrs");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-accesskey-attrs", rule, {
   valid: [
@@ -12,6 +13,24 @@ ruleTester.run("no-accesskey-attrs", rule, {
   invalid: [
     {
       code: `<div accesskey="h"></div>`,
+      errors: [
+        {
+          message: "Unexpected use of accesskey attribute.",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-accesskey-attrs", rule, {
+  valid: [
+    {
+      code: `html\`<div></div>\``,
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<div accesskey="h"></div>\``,
       errors: [
         {
           message: "Unexpected use of accesskey attribute.",

--- a/packages/eslint-plugin/tests/rules/no-aria-hidden-body.test.js
+++ b/packages/eslint-plugin/tests/rules/no-aria-hidden-body.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-aria-hidden-body");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-aria-hidden-body", rule, {
   valid: [
@@ -26,6 +27,27 @@ ruleTester.run("no-aria-hidden-body", rule, {
     },
     {
       code: `<body aria-hidden="true"> </body>`,
+      errors: [
+        {
+          message: "Unexpected aria-hidden on body tag.",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-aria-hidden-body", rule, {
+  valid: [
+    {
+      code: `html\`<div aria-hidden> </div>\``,
+    },
+    {
+      code: `html\`<body aria-hidden=\${value}> </body>\``,
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<body aria-hidden="true"> </body>\``,
       errors: [
         {
           message: "Unexpected aria-hidden on body tag.",

--- a/packages/eslint-plugin/tests/rules/no-duplicate-id.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-id.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-duplicate-id");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-duplicate-id", rule, {
   valid: [
@@ -43,6 +44,65 @@ ruleTester.run("no-duplicate-id", rule, {
   <a id = "foo"></div>
 </body>
 </html>
+`,
+
+      errors: [
+        {
+          messageId: "duplicateId",
+          line: 4,
+        },
+        {
+          messageId: "duplicateId",
+          line: 5,
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-duplicate-id", rule, {
+  valid: [
+    {
+      code: `
+html\`<html>
+<body>
+  <div id = "foo"></div>
+  <div id = "bar"></div>
+</body>
+</html>\`
+`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+html\`<html>
+<body>
+  <div id = "foo"></div>
+  <a id = "foo"></div>
+</body>
+</html>\`
+`,
+
+      errors: [
+        {
+          messageId: "duplicateId",
+          line: 4,
+        },
+        {
+          messageId: "duplicateId",
+          line: 5,
+        },
+      ],
+    },
+    {
+      code: `
+html\`<html>
+<body>
+  <div id = "\${foo}"></div>
+  <a id = "\${foo}"></div>
+</body>
+</html>\`
 `,
 
       errors: [

--- a/packages/eslint-plugin/tests/rules/no-positive-tabindex.test.js
+++ b/packages/eslint-plugin/tests/rules/no-positive-tabindex.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-positive-tabindex");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-positive-tabindex", rule, {
   valid: [
@@ -23,6 +24,27 @@ ruleTester.run("no-positive-tabindex", rule, {
     },
     {
       code: `<span tabindex="2">foo</span>`,
+      errors: [
+        {
+          messageId: "unexpected",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-positive-tabindex", rule, {
+  valid: [
+    {
+      code: `html\`<span tabindex="0">foo</span>\``,
+    },
+    {
+      code: `html\`<span tabindex="\${index}">foo</span>\``,
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<span tabindex="1">foo</span>\``,
       errors: [
         {
           messageId: "unexpected",

--- a/packages/eslint-plugin/tests/rules/no-restricted-attr-values.test.js
+++ b/packages/eslint-plugin/tests/rules/no-restricted-attr-values.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-restricted-attr-values");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-restricted-attr-values", rule, {
   valid: [
@@ -107,6 +108,40 @@ ruleTester.run("no-restricted-attr-values", rule, {
       errors: [
         {
           message: "please do not use 'data-x'",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[tempalte] no-restricted-attr-values", rule, {
+  valid: [
+    {
+      code: `html\`<div> </div>\``,
+      options: [
+        {
+          attrPatterns: [".*"],
+          attrValuePatterns: ["data-.*"],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<div alt="foo"> </div> <custom-element class="foo"></custom-element>\``,
+      options: [
+        {
+          attrPatterns: ["alt", "class"],
+          attrValuePatterns: ["^foo$"],
+          message: "no foo for alt or class",
+        },
+      ],
+      errors: [
+        {
+          message: "no foo for alt or class",
+        },
+        {
+          message: "no foo for alt or class",
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-restricted-attr-values.test.js
+++ b/packages/eslint-plugin/tests/rules/no-restricted-attr-values.test.js
@@ -114,7 +114,7 @@ ruleTester.run("no-restricted-attr-values", rule, {
   ],
 });
 
-templateRuleTester.run("[tempalte] no-restricted-attr-values", rule, {
+templateRuleTester.run("[template] no-restricted-attr-values", rule, {
   valid: [
     {
       code: `html\`<div> </div>\``,

--- a/packages/eslint-plugin/tests/rules/no-restricted-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-restricted-attrs.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-restricted-attrs");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-restricted-attrs", rule, {
   valid: [
@@ -80,6 +81,37 @@ ruleTester.run("no-restricted-attrs", rule, {
     // custom message
     {
       code: `<div data-x="1"> </div>`,
+      options: [
+        {
+          tagPatterns: [".*"],
+          attrPatterns: ["data-.*"],
+          message: "please do not use 'data-x'",
+        },
+      ],
+      errors: [
+        {
+          message: "please do not use 'data-x'",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-restricted-attrs", rule, {
+  valid: [
+    {
+      code: `html\`<div> </div>\``,
+      options: [
+        {
+          tagPatterns: [".*"],
+          attrPatterns: ["data-.*"],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<div data-x="1"> </div>\``,
       options: [
         {
           tagPatterns: [".*"],

--- a/packages/eslint-plugin/tests/rules/no-script-style-type.test.js
+++ b/packages/eslint-plugin/tests/rules/no-script-style-type.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-script-style-type");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-script-style-type", rule, {
   valid: [
@@ -37,6 +38,25 @@ ruleTester.run("no-script-style-type", rule, {
     {
       code: '<link type="text/css" rel="stylesheet" href="https://styles.css" />',
       output: '<link  rel="stylesheet" href="https://styles.css" />',
+      errors: [
+        {
+          messageId: "unnecessary",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-script-style-type", rule, {
+  valid: [
+    {
+      code: 'html`<script src="https://script.js"></script>"`',
+    },
+  ],
+  invalid: [
+    {
+      code: 'html`<script type="text/javascript" src="https://script.js"></script>`',
+      output: 'html`<script  src="https://script.js"></script>`',
       errors: [
         {
           messageId: "unnecessary",

--- a/packages/eslint-plugin/tests/rules/no-target-blank.test.js
+++ b/packages/eslint-plugin/tests/rules/no-target-blank.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-target-blank");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-target-blank", rule, {
   valid: [
@@ -21,6 +22,30 @@ ruleTester.run("no-target-blank", rule, {
   invalid: [
     {
       code: `<a target='_blank' href='http://www.foo.com'></a>`,
+      errors: [
+        {
+          message: 'Missing `rel="noreferrer"` attribute in a tag.',
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-target-blank", rule, {
+  valid: [
+    {
+      code: "html`<a target='_blank' rel='noreferrer' href='http://www.foo.com'></a>`",
+    },
+    {
+      code: "html`<a target='${target}' href='http://www.foo.com'></a>`",
+    },
+    {
+      code: "html`<a target='_blank' rel='${rel}' href='http://www.foo.com'></a>`",
+    },
+  ],
+  invalid: [
+    {
+      code: "html`<a target='_blank' href='http://www.foo.com'></a>`",
       errors: [
         {
           message: 'Missing `rel="noreferrer"` attribute in a tag.',

--- a/packages/eslint-plugin/tests/rules/quotes.test.js
+++ b/packages/eslint-plugin/tests/rules/quotes.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/quotes");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("quotes", rule, {
   valid: [
@@ -140,6 +141,37 @@ foo>`,
       code: `<img src = '?size=50&amp;default=retro'>`,
       output: `<img src = "?size=50&amp;default=retro">`,
       options: ["double"],
+      errors: [
+        {
+          messageId: "unexpected",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] quotes", rule, {
+  valid: [
+    {
+      code: `html\`<div id = " foo ">\``,
+    },
+    {
+      code: `html\`<div id = "\${foo}">\``,
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<div id = ' foo '>\``,
+      output: `html\`<div id = " foo ">\``,
+      errors: [
+        {
+          messageId: "unexpected",
+        },
+      ],
+    },
+    {
+      code: `html\`<div id = ' foo '>\``,
+      output: `html\`<div id = " foo ">\``,
       errors: [
         {
           messageId: "unexpected",

--- a/packages/eslint-plugin/tests/rules/require-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/require-attrs.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/require-attrs");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("require-attrs", rule, {
   valid: [
@@ -244,6 +245,49 @@ ruleTester.run("require-attrs", rule, {
           line: 1,
           column: 6,
           endColumn: 19,
+          message: "Unexpected 'class' attributes value. 'img' is expected",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] require-attrs", rule, {
+  valid: [
+    {
+      code: "html`<svg viewBox></svg>`",
+      options: [
+        {
+          tag: "svg",
+          attr: "viewBox",
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: 'html`<img class="image"/>`',
+      options: [
+        {
+          tag: "img",
+          attr: "alt",
+        },
+        {
+          tag: "img",
+          attr: "class",
+          value: "img",
+        },
+      ],
+      errors: [
+        {
+          line: 1,
+          column: 6,
+          message: "Missing 'alt' attributes for 'img' tag",
+        },
+        {
+          line: 1,
+          column: 11,
+          endColumn: 24,
           message: "Unexpected 'class' attributes value. 'img' is expected",
         },
       ],

--- a/packages/eslint-plugin/tests/rules/require-button-type.test.js
+++ b/packages/eslint-plugin/tests/rules/require-button-type.test.js
@@ -45,6 +45,9 @@ templateRuleTester.run("[template] require-button-type", rule, {
     {
       code: 'html`<button type="submit">Submit Button</button>`',
     },
+    {
+      code: 'html`<button type="${type}">Submit Button</button>`',
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/require-button-type.test.js
+++ b/packages/eslint-plugin/tests/rules/require-button-type.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/require-button-type");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("require-button-type", rule, {
   valid: [
@@ -33,6 +34,26 @@ ruleTester.run("require-button-type", rule, {
           message: '"invalid" is an invalid value for button type attribute.',
           line: 1,
           column: 9,
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] require-button-type", rule, {
+  valid: [
+    {
+      code: 'html`<button type="submit">Submit Button</button>`',
+    },
+  ],
+  invalid: [
+    {
+      code: "html`<button>Missing type</button>`",
+      errors: [
+        {
+          messageId: "missing",
+          line: 1,
+          column: 6,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/require-closing-tags.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/require-closing-tags");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("require-closing-tags", rule, {
   valid: [
@@ -211,6 +212,24 @@ ruleTester.run("require-closing-tags", rule, {
       errors: [
         {
           messageId: "unexpected",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] require-closing-tags", rule, {
+  valid: [
+    {
+      code: "html`<div></div>`",
+    },
+  ],
+  invalid: [
+    {
+      code: "html`<div>`",
+      errors: [
+        {
+          messageId: "missing",
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/require-frame-title.test.js
+++ b/packages/eslint-plugin/tests/rules/require-frame-title.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/require-frame-title");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("require-frame-title", rule, {
   valid: [
@@ -69,6 +70,27 @@ ruleTester.run("require-frame-title", rule, {
 <frameset cols="10%, 90%">
 <frame src="nav.html" title/>
 </frameset>`,
+      errors: [
+        {
+          messageId: "unexpected",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] require-iframe-title", rule, {
+  valid: [
+    {
+      code: 'html`<iframe title="foo"></iframe>`',
+    },
+    {
+      code: 'html`<iframe title="${title}"></iframe>`',
+    },
+  ],
+  invalid: [
+    {
+      code: 'html`<iframe title=""></iframe>`',
       errors: [
         {
           messageId: "unexpected",

--- a/packages/eslint-plugin/tests/rules/require-img-alt.test.js
+++ b/packages/eslint-plugin/tests/rules/require-img-alt.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/require-img-alt");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("require-img-alt", rule, {
   valid: [
@@ -100,6 +101,31 @@ ruleTester.run("require-img-alt", rule, {
           column: 5,
           endColumn: 28,
           endLine: 4,
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] require-img-alt", rule, {
+  valid: [
+    {
+      code: `html\`<img src="./image.png" alt="image description"/>\``,
+    },
+    {
+      code: `html\`<img src="./image.png" alt="\${alt}"/>\``,
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<img src="./image.png"/>\``,
+      errors: [
+        {
+          messageId: "missingAlt",
+          line: 1,
+          column: 6,
+          endColumn: 30,
+          endLine: 1,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/require-lang.test.js
+++ b/packages/eslint-plugin/tests/rules/require-lang.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/require-lang");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("require-lang", rule, {
   valid: [
@@ -50,6 +51,27 @@ ruleTester.run("require-lang", rule, {
       errors: [
         {
           messageId: "empty",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] require-lang", rule, {
+  valid: [
+    {
+      code: `html\`<html lang="ko"></html>\``,
+    },
+    {
+      code: `html\`<html lang="\${lang}"></html>\``,
+    },
+  ],
+  invalid: [
+    {
+      code: `html\`<html></html>\``,
+      errors: [
+        {
+          messageId: "missing",
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/sort-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/sort-attrs.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/sort-attrs");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("sort-attrs", rule, {
   valid: [
@@ -194,6 +195,90 @@ ruleTester.run("sort-attrs", rule, {
           priority: ["id", "style"],
         },
       ],
+      errors: [
+        {
+          messageId: "unsorted",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] sort-attrs", rule, {
+  valid: [
+    {
+      code: 'html`<input id="foo" type="checkbox" autocomplete="bar" checked />`',
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        html\`<div
+          style="background:red"
+          b
+          id="foo"
+          a="1"
+          c
+        >
+        </div>\`
+      `,
+      output: `
+        html\`<div
+          id="foo"
+          style="background:red"
+          a="1"
+          b
+          c
+        >
+        </div>\`
+      `,
+      options: [
+        {
+          priority: ["id", "style"],
+        },
+      ],
+      errors: [
+        {
+          messageId: "unsorted",
+        },
+      ],
+    },
+    {
+      code: `
+        html\`<div
+          style="background:red"
+          b
+          id="\${foo}"
+          a="1"
+          c
+        >
+        </div>\`
+      `,
+      output: `
+        html\`<div
+          id="\${foo}"
+          style="background:red"
+          a="1"
+          b
+          c
+        >
+        </div>\`
+      `,
+      options: [
+        {
+          priority: ["id", "style"],
+        },
+      ],
+      errors: [
+        {
+          messageId: "unsorted",
+        },
+      ],
+    },
+    {
+      code: 'html`<input ${some} id="foo" type="checkbox" autocomplete="bar" checked />`',
+      output:
+        'html`<input id="foo" type="checkbox" ${some} autocomplete="bar" checked />`',
       errors: [
         {
           messageId: "unsorted",


### PR DESCRIPTION
#225 
 Applying template-parser to the rules
      - no-accesskey-attrs 
      - no-aria-hidden-body 
      - no-duplicate-id 
      - no-restricted-attrs 
      - no-restricted-attr-values 
      - no-positive-tabindex 
      - no-script-style-type  
      - no-target-blank 
      - quotes 
      - require-attrs 
      - require-button-type 
      - require-closing-tags 
      - require-frame-title 
      - require-img-alt 
      - require-lang  
      - sort-attrs  