### PR TITLE
feat: support linting html in template literals in no-extra-spacing-text

### DIFF
--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -1,6 +1,5 @@
 /**
  * @typedef { import("../types").RuleModule } RuleModule
- * @typedef { import("../types").ProgramNode } ProgramNode
  * @typedef { import("../types").TagNode } TagNode
  * @typedef { import("../types").BaseNode } BaseNode
  * @typedef { import("../types").CommentNode } CommentNode
@@ -302,20 +301,11 @@ module.exports = {
       return true;
     }
 
-    return createVisitors(
-      context,
-      {
-        Program(node) {
-          // @ts-ignore
-          checkSiblings(node.body);
-        },
-      },
-      {
+    return createVisitors(context, {
+      Document(node) {
         // @ts-ignore
-        Document(node) {
-          checkSiblings(node.children);
-        },
-      }
-    );
+        checkSiblings(node.children);
+      },
+    });
   },
 };

--- a/packages/eslint-plugin/lib/rules/no-duplicate-id.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-id.js
@@ -85,7 +85,7 @@ module.exports = {
 
     return {
       Tag: createTagVisitor(htmlIdAttrsMap),
-      "Program:exit"() {
+      "Document:exit"() {
         report(htmlIdAttrsMap);
       },
       TaggedTemplateExpression(node) {

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-text.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-text.js
@@ -11,7 +11,7 @@
  */
 
 const { RULE_CATEGORY } = require("../constants");
-const { isTag, splitToLineNodes } = require("./utils/node");
+const { isTag, isOverlapWithTemplates } = require("./utils/node");
 const { getSourceCode } = require("./utils/source-code");
 const { createVisitors } = require("./utils/visitors");
 
@@ -89,9 +89,7 @@ module.exports = {
     function stripConsecutiveSpaces(node) {
       const text = node.value;
       const matcher = /(^|[^\n \t])([ \t]+\n|\t[\t ]*|[ \t]{2,})/g;
-      const templates = node.templates.filter(
-        (template) => template.isTemplate
-      );
+
       // eslint-disable-next-line no-constant-condition
       while (true) {
         const offender = matcher.exec(text);
@@ -103,9 +101,11 @@ module.exports = {
         const indexStart = node.range[0] + matcher.lastIndex - space.length;
         const indexEnd = indexStart + space.length;
 
-        const hasOverlap = templates.some((template) => {
-          return template.range[0] < indexEnd && indexStart < template.range[1];
-        });
+        const hasOverlap = isOverlapWithTemplates(node.templates, [
+          indexStart,
+          indexEnd,
+        ]);
+
         if (hasOverlap) {
           return;
         }

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-text.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-text.js
@@ -1,6 +1,5 @@
 /**
  * @typedef { import("../types").RuleModule } RuleModule
- * @typedef { import("../types").ProgramNode } ProgramNode
  * @typedef { import("es-html-parser").CommentContentNode } CommentContentNode
  * @typedef { import("es-html-parser").TagNode } TagNode
  * @typedef { import("es-html-parser").CommentNode } CommentNode

--- a/packages/eslint-plugin/lib/rules/no-multiple-empty-lines.js
+++ b/packages/eslint-plugin/lib/rules/no-multiple-empty-lines.js
@@ -1,6 +1,5 @@
 /**
  * @typedef { import("../types").RuleModule } RuleModule
- * @typedef { import("../types").ProgramNode } ProgramNode
  */
 
 const { RULE_CATEGORY } = require("../constants");
@@ -46,10 +45,7 @@ module.exports = {
     const lines = sourceCode.lines;
     const max = context.options.length ? context.options[0].max : 2;
     return {
-      /**
-       * @param {ProgramNode} node
-       */
-      "Program:exit"(node) {
+      "Document:exit"(node) {
         /** @type {number[]} */
         const nonEmptyLineNumbers = [];
 

--- a/packages/eslint-plugin/lib/rules/no-multiple-empty-lines.js
+++ b/packages/eslint-plugin/lib/rules/no-multiple-empty-lines.js
@@ -1,8 +1,23 @@
 /**
  * @typedef { import("../types").RuleModule } RuleModule
+ * @typedef { import("es-html-parser").DocumentNode } DocumentNode
+ * @typedef { import("es-html-parser").AnyToken } AnyToken
+ * @typedef { import("es-html-parser").CommentContentNode } CommentContentNode
+ * @typedef { import("es-html-parser").TextNode } TextNode
  */
 
+const { parse } = require("@html-eslint/template-parser");
 const { RULE_CATEGORY } = require("../constants");
+const {
+  shouldCheckTaggedTemplateExpression,
+  shouldCheckTemplateLiteral,
+} = require("./utils/settings");
+const { getSourceCode } = require("./utils/source-code");
+const {
+  codeToLines,
+  isRangesOverlap,
+  getTemplateTokens,
+} = require("./utils/node");
 
 const MESSAGE_IDS = {
   UNEXPECTED: "unexpected",
@@ -41,49 +56,90 @@ module.exports = {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
-    const lines = sourceCode.lines;
     const max = context.options.length ? context.options[0].max : 2;
-    return {
-      "Document:exit"(node) {
-        /** @type {number[]} */
-        const nonEmptyLineNumbers = [];
+    const sourceCode = getSourceCode(context);
 
-        lines.forEach((line, index) => {
-          if (line.trim().length > 0) {
-            nonEmptyLineNumbers.push(index + 1);
-          }
-        });
+    /**
+     * @param {string[]} lines
+     * @param {number} lineOffset
+     * @param {((CommentContentNode | TextNode)['templates'][number])[]} tokens
+     */
+    function check(lines, lineOffset, tokens) {
+      /** @type {number[]} */
+      const nonEmptyLineNumbers = [];
 
-        nonEmptyLineNumbers.forEach((current, index, arr) => {
-          const before = arr[index - 1];
-          if (typeof before === "number") {
-            if (current - before - 1 > max) {
-              context.report({
-                node,
-                loc: {
-                  start: { line: before, column: 0 },
-                  end: { line: current, column: 0 },
-                },
-                messageId: MESSAGE_IDS.UNEXPECTED,
-                data: {
-                  max,
-                },
-                fix(fixer) {
-                  const start = sourceCode.getIndexFromLoc({
-                    line: before + 1,
-                    column: 0,
-                  });
-                  const end = sourceCode.getIndexFromLoc({
-                    line: current - max,
-                    column: 0,
-                  });
-                  return fixer.removeRange([start, end]);
-                },
-              });
+      lines.forEach((line, index) => {
+        if (line.trim().length > 0) {
+          nonEmptyLineNumbers.push(index + lineOffset);
+        }
+      });
+
+      nonEmptyLineNumbers.forEach((current, index, arr) => {
+        const before = arr[index - 1];
+        if (typeof before === "number") {
+          if (current - before - 1 > max) {
+            const start = sourceCode.getIndexFromLoc({
+              line: before + 1,
+              column: 0,
+            });
+            const end = sourceCode.getIndexFromLoc({
+              line: current - max,
+              column: 0,
+            });
+            if (
+              tokens.some((token) => isRangesOverlap(token.range, [start, end]))
+            ) {
+              return;
             }
+
+            context.report({
+              loc: {
+                start: { line: before, column: 0 },
+                end: { line: current, column: 0 },
+              },
+              messageId: MESSAGE_IDS.UNEXPECTED,
+              data: {
+                max,
+              },
+              fix(fixer) {
+                return fixer.removeRange([start, end]);
+              },
+            });
           }
-        });
+        }
+      });
+    }
+    return {
+      "Document:exit"() {
+        check(sourceCode.lines, 1, []);
+      },
+      TaggedTemplateExpression(node) {
+        if (shouldCheckTaggedTemplateExpression(node, context)) {
+          const { html, tokens } = parse(
+            node.quasi,
+            getSourceCode(context),
+            {}
+          );
+          const lines = codeToLines(html);
+          check(
+            lines,
+            // @ts-ignore
+            node.quasi.loc.start.line,
+            getTemplateTokens(tokens)
+          );
+        }
+      },
+      TemplateLiteral(node) {
+        if (shouldCheckTemplateLiteral(node, context)) {
+          const { html, tokens } = parse(node, getSourceCode(context), {});
+          const lines = codeToLines(html);
+          check(
+            lines,
+            // @ts-ignore
+            node.quasi.loc.start.line,
+            getTemplateTokens(tokens)
+          );
+        }
       },
     };
   },

--- a/packages/eslint-plugin/lib/rules/no-multiple-h1.js
+++ b/packages/eslint-plugin/lib/rules/no-multiple-h1.js
@@ -41,7 +41,7 @@ module.exports = {
           h1s.push(node);
         }
       },
-      "Program:exit"() {
+      "Document:exit"() {
         if (h1s.length > 1) {
           h1s.forEach((h1) => {
             context.report({

--- a/packages/eslint-plugin/lib/rules/no-skip-heading-levels.js
+++ b/packages/eslint-plugin/lib/rules/no-skip-heading-levels.js
@@ -46,7 +46,7 @@ module.exports = {
           level: parseInt(node.name.replace("h", ""), 10),
         });
       },
-      "Program:exit"() {
+      "Document:exit"() {
         if (headings.length <= 1) {
           return;
         }

--- a/packages/eslint-plugin/lib/rules/no-trailing-spaces.js
+++ b/packages/eslint-plugin/lib/rules/no-trailing-spaces.js
@@ -1,8 +1,21 @@
 /**
  * @typedef { import("../types").RuleModule } RuleModule
+ * @typedef { import("es-html-parser").CommentContentNode } CommentContentNode
+ * @typedef { import("es-html-parser").TextNode } TextNode
  */
 
+const { parse } = require("@html-eslint/template-parser");
 const { RULE_CATEGORY } = require("../constants");
+const {
+  getTemplateTokens,
+  codeToLines,
+  isRangesOverlap,
+} = require("./utils/node");
+const {
+  shouldCheckTaggedTemplateExpression,
+  shouldCheckTemplateLiteral,
+} = require("./utils/settings");
+const { getSourceCode } = require("./utils/source-code");
 
 const MESSAGE_IDS = {
   TRAILING_SPACE: "trailingSpace",
@@ -27,49 +40,91 @@ module.exports = {
   },
 
   create(context) {
-    const sourceCode = context.getSourceCode();
-    // @ts-ignore
-    const lineBreaks = sourceCode.getText().match(/\r\n|[\r\n\u2028\u2029]/gu);
+    const sourceCode = getSourceCode(context);
+    /**
+     * @param {string} source
+     * @param {string[]} lines
+     * @param {number} rangeOffset
+     * @param {((CommentContentNode | TextNode)['templates'][number])[]} tokens
+     */
+    function check(source, lines, rangeOffset, tokens) {
+      let rangeIndex = rangeOffset;
+      const lineBreaks = source.match(/\r\n|[\r\n\u2028\u2029]/gu);
+      lines.forEach((line, index) => {
+        const lineNumber = index + 1;
+        const match = line.match(/[ \t\u00a0\u2000-\u200b\u3000]+$/);
+        const lineBreakLength =
+          lineBreaks && lineBreaks[index] ? lineBreaks[index].length : 1;
+        const lineLength = line.length + lineBreakLength;
+
+        if (match) {
+          if (typeof match.index === "number" && match.index > 0) {
+            const loc = {
+              start: {
+                line: lineNumber,
+                column: match.index,
+              },
+              end: {
+                line: lineNumber,
+                column: lineLength - lineBreakLength,
+              },
+            };
+            const start = sourceCode.getIndexFromLoc(loc.start);
+            const end = sourceCode.getIndexFromLoc(loc.end);
+            if (
+              tokens.some((token) => isRangesOverlap(token.range, [start, end]))
+            ) {
+              return;
+            }
+            context.report({
+              messageId: MESSAGE_IDS.TRAILING_SPACE,
+              loc,
+              fix(fixer) {
+                return fixer.removeRange([
+                  rangeIndex + loc.start.column,
+                  rangeIndex + loc.end.column,
+                ]);
+              },
+            });
+          }
+        }
+        rangeIndex += lineLength;
+      });
+    }
 
     return {
       Document() {
-        const lines = sourceCode.lines;
-        let rangeIndex = 0;
-
-        lines.forEach((line, index) => {
-          const lineNumber = index + 1;
-          const match = line.match(/[ \t\u00a0\u2000-\u200b\u3000]+$/);
-          const lineBreakLength =
-            lineBreaks && lineBreaks[index] ? lineBreaks[index].length : 1;
-          const lineLength = line.length + lineBreakLength;
-
-          if (match) {
-            if (typeof match.index === "number" && match.index > 0) {
-              const loc = {
-                start: {
-                  line: lineNumber,
-                  column: match.index,
-                },
-                end: {
-                  line: lineNumber,
-                  column: lineLength - lineBreakLength,
-                },
-              };
-
-              context.report({
-                messageId: MESSAGE_IDS.TRAILING_SPACE,
-                loc,
-                fix(fixer) {
-                  return fixer.removeRange([
-                    rangeIndex + loc.start.column,
-                    rangeIndex + loc.end.column,
-                  ]);
-                },
-              });
-            }
-          }
-          rangeIndex += lineLength;
-        });
+        check(sourceCode.getText(), sourceCode.getLines(), 0, []);
+      },
+      TaggedTemplateExpression(node) {
+        if (shouldCheckTaggedTemplateExpression(node, context)) {
+          const { html, tokens } = parse(
+            node.quasi,
+            getSourceCode(context),
+            {}
+          );
+          const lines = codeToLines(html);
+          check(
+            html,
+            lines,
+            // @ts-ignore
+            node.quasi.range[0] + 1,
+            getTemplateTokens(tokens)
+          );
+        }
+      },
+      TemplateLiteral(node) {
+        if (shouldCheckTemplateLiteral(node, context)) {
+          const { html, tokens } = parse(node, getSourceCode(context), {});
+          const lines = codeToLines(html);
+          check(
+            html,
+            lines,
+            // @ts-ignore
+            node.range[0] + 1,
+            getTemplateTokens(tokens)
+          );
+        }
       },
     };
   },

--- a/packages/eslint-plugin/lib/rules/no-trailing-spaces.js
+++ b/packages/eslint-plugin/lib/rules/no-trailing-spaces.js
@@ -32,7 +32,7 @@ module.exports = {
     const lineBreaks = sourceCode.getText().match(/\r\n|[\r\n\u2028\u2029]/gu);
 
     return {
-      Program() {
+      Document() {
         const lines = sourceCode.lines;
         let rangeIndex = 0;
 

--- a/packages/eslint-plugin/lib/rules/require-li-container.js
+++ b/packages/eslint-plugin/lib/rules/require-li-container.js
@@ -38,7 +38,7 @@ module.exports = {
         if (node.name !== "li") {
           return;
         }
-        if (!node.parent || node.parent.type === NODE_TYPES.Program) {
+        if (!node.parent || node.parent.type === NODE_TYPES.Document) {
           context.report({
             node,
             messageId: MESSAGE_IDS.INVALID,

--- a/packages/eslint-plugin/lib/rules/utils/node.js
+++ b/packages/eslint-plugin/lib/rules/utils/node.js
@@ -8,6 +8,7 @@
  * @typedef { import("es-html-parser").TextNode } TextNode
  * @typedef { import("es-html-parser").CommentContentNode } CommentContentNode
  * @typedef { import("es-html-parser").CommentNode } CommentNode
+ * @typedef { import("es-html-parser").AnyToken} AnyToken
  * @typedef { import("../../types").LineNode } LineNode
  * @typedef { import("../../types").BaseNode } BaseNode
  * @typedef { import("../../types").Location } Location
@@ -195,6 +196,34 @@ function isText(node) {
   return node.type === NODE_TYPES.Text;
 }
 
+const lineBreakPattern = /\r\n|[\r\n\u2028\u2029]/u;
+const lineEndingPattern = new RegExp(lineBreakPattern.source, "gu");
+/**
+ * @param {string} source
+ * @returns {string[]}
+ */
+function codeToLines(source) {
+  return source.split(lineEndingPattern);
+}
+
+/**
+ *
+ * @param {AnyToken[]} tokens
+ * @returns {((CommentContentNode | TextNode)['templates'][number])[]}
+ */
+function getTemplateTokens(tokens) {
+  return (
+    []
+      .concat(
+        ...tokens
+          // @ts-ignore
+          .map((token) => token["templates"] || [])
+      )
+      // @ts-ignore
+      .filter((token) => token.isTemplate)
+  );
+}
+
 module.exports = {
   findAttr,
   isAttributesEmpty,
@@ -206,4 +235,7 @@ module.exports = {
   isComment,
   isText,
   isOverlapWithTemplates,
+  codeToLines,
+  isRangesOverlap,
+  getTemplateTokens,
 };

--- a/packages/eslint-plugin/lib/types.d.ts
+++ b/packages/eslint-plugin/lib/types.d.ts
@@ -19,12 +19,6 @@ export interface BaseNode {
   };
 }
 
-export interface ProgramNode
-  extends Omit<ESHtml.DocumentNode, "type" | "children"> {
-  type: "Program";
-  body: ESHtml.DocumentNode["children"];
-}
-
 interface AttributeKeyNode extends ESHtml.AttributeKeyNode {
   parent: AttributeNode;
 }
@@ -35,7 +29,7 @@ interface TextNode extends ESHtml.TextNode {
 
 export interface TagNode extends ESHtml.TagNode {
   attributes: AttributeNode[];
-  parent: TagNode | ProgramNode;
+  parent: TagNode | HTMLNode;
   openStart: OpenTagStartNode;
   openEnd: OpenTagEndNode;
   close: CloseTagNode;
@@ -78,7 +72,7 @@ interface AttributeValueWrapperStartNode
 
 export interface ScriptTagNode extends ESHtml.ScriptTagNode {
   attributes: AttributeNode[];
-  parent: ProgramNode | TagNode;
+  parent: HTMLNode | TagNode;
   openStart: OpenScriptTagStartNode;
   openEnd: OpenScriptTagEndNode;
 }
@@ -101,7 +95,7 @@ interface ScriptTagContentNode extends ESHtml.ScriptTagContentNode {
 
 export interface StyleTagNode extends ESHtml.StyleTagNode {
   attributes: AttributeNode[];
-  parent: TagNode | ProgramNode;
+  parent: TagNode | HTMLNode;
   openStart: OpenStyleTagStartNode;
   openEnd: OpenStyleTagEndNode;
 }
@@ -123,7 +117,7 @@ interface CloseStyleTagNode extends ESHtml.CloseStyleTagNode {
 }
 
 interface CommentNode extends ESHtml.CommentNode {
-  parent: ProgramNode | TagNode;
+  parent: HTMLNode | TagNode;
 }
 
 interface CommentOpenNode extends ESHtml.CommentOpenNode {
@@ -139,7 +133,7 @@ interface CommentContentNode extends ESHtml.CommentContentNode {
 }
 
 interface DoctypeNode extends ESHtml.DoctypeNode {
-  parent: ProgramNode;
+  parent: HTMLNode;
 }
 
 interface DoctypeOpenNode extends ESHtml.DoctypeOpenNode {
@@ -182,7 +176,7 @@ export type RuleListener = BaseRuleListener &
   PostFix<BaseRuleListener, ":exit">;
 
 interface BaseRuleListener {
-  Program?: (node: ProgramNode) => void;
+  Document?: (node: ESHtml.DocumentNode) => void;
   AttributeKey?: (node: AttributeKeyNode) => void;
   Text?: (node: TextNode) => void;
   Tag?: (node: TagNode) => void;
@@ -271,12 +265,6 @@ type ReportDescriptorLocation = {
 export interface Context extends Omit<ESLint.Rule.RuleContext, "report"> {
   report(descriptor: ReportDescriptor): void;
 }
-
-export type ChildType<T extends BaseNode> = T extends ProgramNode
-  ? T["body"][number]
-  : T extends TagNode
-  ? T["children"][number]
-  : never;
 
 export type ContentNode =
   | CommentNode

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -52,7 +52,7 @@
     "@html-eslint/template-parser": "^0.27.0",
     "@types/eslint": "^9.6.1",
     "@types/estree": "^0.0.47",
-    "es-html-parser": "^1.0.0-alpha.3",
+    "es-html-parser": "^1.0.0-alpha.4",
     "espree": "^10.3.0",
     "typescript": "^5.7.2"
   }

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-text.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-text.test.js
@@ -26,13 +26,13 @@ function errorsAt(...positions) {
 }
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-extra-spacing-text", rule, {
   valid: [
     {
       code: `<div> foo </div>`,
     },
-
     {
       code: `<div> foo bar </div>`,
     },
@@ -146,6 +146,48 @@ ruleTester.run("no-extra-spacing-text", rule, {
         [3, 41, 3],
         [3, 48, 3]
       ),
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-extra-spacing-text", rule, {
+  valid: [
+    {
+      code: "html`<div> foo </div>`",
+    },
+    {
+      code: `html\`
+\t  <div>
+    \t  <div>
+      foo
+          bar
+    \t\t  </div>
+\t  </div>\`
+`,
+    },
+    {
+      code: `
+html\`<div>
+      \${items => {    }}
+</div>\`
+      `,
+    },
+    {
+      code: `
+html\`<div>
+      \${items => { 
+        var foo;    var bar;   
+        
+        }}
+</div>\`
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: "html`<div>foo\t\n</div>`",
+      output: "html`<div>foo\n</div>`",
+      errors: errorsAt([1, 14, 2, 1]),
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-multiple-empty-lines.test.js
+++ b/packages/eslint-plugin/tests/rules/no-multiple-empty-lines.test.js
@@ -2,7 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-multiple-empty-lines");
 
 const ruleTester = createRuleTester();
-const teaplateRuleTester = createRuleTester("espree");
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-multiple-empty-lines", rule, {
   valid: [
@@ -95,7 +95,7 @@ ruleTester.run("no-multiple-empty-lines", rule, {
   ],
 });
 
-teaplateRuleTester.run("[template] no-multiple-empty-lines", rule, {
+templateRuleTester.run("[template] no-multiple-empty-lines", rule, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-multiple-empty-lines.test.js
+++ b/packages/eslint-plugin/tests/rules/no-multiple-empty-lines.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-multiple-empty-lines");
 
 const ruleTester = createRuleTester();
+const teaplateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-multiple-empty-lines", rule, {
   valid: [
@@ -88,6 +89,74 @@ ruleTester.run("no-multiple-empty-lines", rule, {
         },
         {
           message: "More than 1 blank lines not allowed.",
+        },
+      ],
+    },
+  ],
+});
+
+teaplateRuleTester.run("[template] no-multiple-empty-lines", rule, {
+  valid: [
+    {
+      code: `
+html\`<html>
+<body>
+<div></div>
+</body>
+</html>\`
+`,
+    },
+    {
+      code: `
+const html = \`
+
+
+
+\`
+`,
+    },
+    {
+      code: `
+html\`
+<body>
+\${(() => {
+  
+  
+
+
+  return "<div></div>"
+})()}
+</body>
+\`
+`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+html\`<html>
+<body>
+<div>
+
+
+
+</div>
+</body>
+</html>\`
+`,
+      output: `
+html\`<html>
+<body>
+<div>
+
+
+</div>
+</body>
+</html>\`
+`,
+      errors: [
+        {
+          message: "More than 2 blank lines not allowed.",
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-trailing-spaces.test.js
+++ b/packages/eslint-plugin/tests/rules/no-trailing-spaces.test.js
@@ -2,6 +2,7 @@ const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-trailing-spaces");
 
 const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
 
 ruleTester.run("no-tailing-spaces", rule, {
   valid: [
@@ -65,4 +66,17 @@ ruleTester.run("no-tailing-spaces", rule, {
       ],
     },
   ],
+});
+
+templateRuleTester.run("[template] no-tailing-spaces", rule, {
+  valid: [
+    {
+      code: `html\`<div>
+      \${(() => {
+        return ""      \t\t
+      })()}
+</div>\``,
+    },
+  ],
+  invalid: [],
 });

--- a/packages/parser/lib/node-types.js
+++ b/packages/parser/lib/node-types.js
@@ -1,12 +1,6 @@
 const { NodeTypes } = require("es-html-parser");
 
-// eslint-disable-next-line no-unused-vars
-const { Document, ...restNodeTypes } = NodeTypes;
-
-const NODE_TYPES = {
-  Program: "Program",
-  ...restNodeTypes,
-};
+const NODE_TYPES = NodeTypes;
 
 module.exports = {
   NODE_TYPES,

--- a/packages/parser/lib/parser.js
+++ b/packages/parser/lib/parser.js
@@ -15,7 +15,7 @@ module.exports.parseForESLint = function parseForESLint(code) {
 
   const programNode = {
     type: "Program",
-    body: ast.children,
+    body: [ast],
     loc: ast.loc,
     range: ast.range,
     tokens: tokens.filter(

--- a/packages/parser/lib/visitor-keys.js
+++ b/packages/parser/lib/visitor-keys.js
@@ -1,7 +1,8 @@
 const { NODE_TYPES } = require("./node-types");
 
 const visitorKeys = {
-  [NODE_TYPES.Program]: ["body"],
+  Program: ["body"],
+  [NODE_TYPES.Document]: ["children"],
   [NODE_TYPES.Attribute]: ["key", "startWrapper", "endWrapper", "value"],
   [NODE_TYPES.AttributeKey]: [],
   [NODE_TYPES.AttributeValue]: [],

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/yeonjuan/html-eslint/issues"
   },
   "dependencies": {
-    "es-html-parser": "^1.0.0-alpha.3"
+    "es-html-parser": "^1.0.0-alpha.4"
   },
   "devDependencies": {
     "typescript": "^5.7.2"

--- a/packages/template-parser/lib/template-parser.js
+++ b/packages/template-parser/lib/template-parser.js
@@ -39,7 +39,7 @@ function parse(node, sourceCode, visitors) {
     }
   });
   const html = htmlParts.join("");
-  const { ast } = esHtmlParser.parse(html, {
+  const { ast, tokens } = esHtmlParser.parse(html, {
     templateRanges: ranges,
     tokenAdapter: {
       finalizeLocation(token) {
@@ -64,7 +64,7 @@ function parse(node, sourceCode, visitors) {
     },
   });
   traverse(ast, visitors);
-  return ast;
+  return { ast, html, tokens };
 }
 
 module.exports = {

--- a/packages/template-parser/package.json
+++ b/packages/template-parser/package.json
@@ -36,7 +36,7 @@
     "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "dependencies": {
-    "es-html-parser": "^1.0.0-alpha.3"
+    "es-html-parser": "^1.0.0-alpha.4"
   },
   "devDependencies": {
     "@types/estree": "^0.0.47",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,7 +1253,7 @@ __metadata:
     "@html-eslint/template-parser": "npm:^0.27.0"
     "@types/eslint": "npm:^9.6.1"
     "@types/estree": "npm:^0.0.47"
-    es-html-parser: "npm:^1.0.0-alpha.3"
+    es-html-parser: "npm:^1.0.0-alpha.4"
     espree: "npm:^10.3.0"
     typescript: "npm:^5.7.2"
   languageName: unknown
@@ -1281,7 +1281,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@html-eslint/parser@workspace:packages/parser"
   dependencies:
-    es-html-parser: "npm:^1.0.0-alpha.3"
+    es-html-parser: "npm:^1.0.0-alpha.4"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
@@ -1291,7 +1291,7 @@ __metadata:
   resolution: "@html-eslint/template-parser@workspace:packages/template-parser"
   dependencies:
     "@types/estree": "npm:^0.0.47"
-    es-html-parser: "npm:^1.0.0-alpha.3"
+    es-html-parser: "npm:^1.0.0-alpha.4"
     eslint: "npm:^9.15.0"
     espree: "npm:^10.3.0"
     globals: "npm:^15.12.0"
@@ -6893,10 +6893,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-html-parser@npm:^1.0.0-alpha.3":
-  version: 1.0.0-alpha.3
-  resolution: "es-html-parser@npm:1.0.0-alpha.3"
-  checksum: d93108f41eb0243f8620eb7757e002e6fd92f6ff9064421bf54854482a757efc67fed48868cdd48ebcb973c8568537f8a0637df02f01fed2d2bf93435d4bbfa4
+"es-html-parser@npm:^1.0.0-alpha.4":
+  version: 1.0.0-alpha.4
+  resolution: "es-html-parser@npm:1.0.0-alpha.4"
+  checksum: 4ed0a0b336ae650e1c39df73b7cad6c850349690455b11e556bd7cf6fa1d5965b310711335f286cfa26c18a0a2f16503ac7461297ff02a7690b08328a71f6e3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Applying template-parser to the rules
- no-extra-spacing-text
- no-multiple-empty-lines
- no-trailing-spaces