### PR TITLE
fix: indentation rules for script and style tags

### DIFF
--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -271,6 +271,7 @@ module.exports = {
         },
         OpenScriptTagStart: checkIndent,
         OpenScriptTagEnd: checkIndent,
+        CloseScriptTag: checkIndent,
         StyleTag(node) {
           indentLevel.indent(node);
         },
@@ -279,6 +280,7 @@ module.exports = {
         },
         OpenStyleTagStart: checkIndent,
         OpenStyleTagEnd: checkIndent,
+        CloseStyleTag: checkIndent,
         OpenTagStart: checkIndent,
         OpenTagEnd(node) {
           checkIndent(node);

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -374,6 +374,14 @@ function createTests() {
           },
         ],
       },
+      {
+        code: `
+<style>
+</style>
+<script>
+</script>
+        `
+      }
     ],
     invalid: [
       {
@@ -1053,6 +1061,21 @@ id="bar"
           },
         ],
       },
+      {
+        code: `
+<style>
+   </style>
+<script>
+  </script>
+        `,
+        output: `
+<style>
+</style>
+<script>
+</script>
+        `,
+        errors: wrongIndentErrors(2),
+      }
     ],
   };
 }


### PR DESCRIPTION
## Issue Addressed
Fixes #264

## Summary
Add the missing handling inside the file `indent.js` to manage the closing tags for script and style

## Tests

Two tests added inside `indent.test.js` to verify:

- if a valid `</script>` tag and `</style>` tag passes without errors
- if an invalid `</script>` tag and `</style>` tag (with incorrect indentation e.g. two extra spaces) triggers errors