### PR TITLE
fix: hasTemplate throwing exception

### DIFF
--- a/packages/eslint-plugin/lib/rules/utils/node.js
+++ b/packages/eslint-plugin/lib/rules/utils/node.js
@@ -73,7 +73,8 @@ function isOverlapWithTemplates(templates, range) {
  * @returns {boolean}
  */
 function hasTemplate(node) {
-  return node.templates.some((template) => template.isTemplate);
+  const templates = node.templates || [];
+  return templates.some((template) => template.isTemplate);
 }
 
 /**


### PR DESCRIPTION
Hey there! I tried pulling in updates from this package recently and ran into an exception with the `@html-eslint/id-naming-convention` rule: This was due to calling `hasTemplate` with a node that had no templates defined. This PR fixes the issue by adding a default (the same logic is used in `splitToLineNodes` below), though it's worth noting there may be other cases of this error that are difficult to spot at a glance due to the lack of type safety around templates rn.