### PR TITLE
fix: disable validation of fewer attributes in `attrs-newline`

### DIFF
--- a/docs/rules/attrs-newline.md
+++ b/docs/rules/attrs-newline.md
@@ -49,7 +49,7 @@ This rule has an object option:
 
 #### ifAttrsMoreThan
 
-If there are more than this number of attributes, all attributes should be separated by newlines. Either they should _not_ be separated by newlines.
+If there are more than this number of attributes, all attributes should be separated by newlines.
 
 The default is `2`.
 

--- a/packages/eslint-plugin/lib/rules/attrs-newline.js
+++ b/packages/eslint-plugin/lib/rules/attrs-newline.js
@@ -4,7 +4,6 @@
  * @typedef {Object} MessageId
  * @property {"closeStyleWrong"} CLOSE_STYLE_WRONG
  * @property {"newlineMissing"} NEWLINE_MISSING
- * @property {"newlineUnexpected"} NEWLINE_UNEXPECTED
  *
  * @typedef {Object} Option
  * @property {"sameline" | "newline"} [option.closeStyle]
@@ -22,7 +21,6 @@ const { createVisitors } = require("./utils/visitors");
 const MESSAGE_ID = {
   CLOSE_STYLE_WRONG: "closeStyleWrong",
   NEWLINE_MISSING: "newlineMissing",
-  NEWLINE_UNEXPECTED: "newlineUnexpected",
 };
 
 /**
@@ -56,8 +54,6 @@ module.exports = {
       [MESSAGE_ID.CLOSE_STYLE_WRONG]:
         "Closing bracket was on {{actual}}; expected {{expected}}",
       [MESSAGE_ID.NEWLINE_MISSING]: "Newline expected before {{attrName}}",
-      [MESSAGE_ID.NEWLINE_UNEXPECTED]:
-        "Newlines not expected between attributes, since this tag has fewer than {{attrMin}} attributes",
     },
   },
 
@@ -70,21 +66,22 @@ module.exports = {
     return createVisitors(context, {
       Tag(node) {
         const shouldBeMultiline = node.attributes.length > attrMin;
+        if (!shouldBeMultiline) return;
 
         /**
          * This doesn't do any indentation, so the result will look silly. Indentation should be covered by the `indent` rule
          * @param {RuleFixer} fixer
          */
         function fix(fixer) {
-          const spacer = shouldBeMultiline ? "\n" : " ";
           let expected = node.openStart.value;
           for (const attr of node.attributes) {
-            expected += `${spacer}${attr.key.value}`;
+            expected += `\n${attr.key.value}`;
             if (attr.startWrapper && attr.value && attr.endWrapper) {
               expected += `=${attr.startWrapper.value}${attr.value.value}${attr.endWrapper.value}`;
             }
           }
-          if (shouldBeMultiline && closeStyle === "newline") {
+
+          if (closeStyle === "newline") {
             expected += "\n";
           } else if (node.selfClosing) {
             expected += " ";
@@ -97,66 +94,38 @@ module.exports = {
           );
         }
 
-        if (shouldBeMultiline) {
-          let index = 0;
-          for (const attr of node.attributes) {
-            const attrPrevious = node.attributes[index - 1];
-            const relativeToNode = attrPrevious || node.openStart;
-            if (attr.loc.start.line === relativeToNode.loc.end.line) {
-              return context.report({
-                node,
-                data: {
-                  attrName: attr.key.value,
-                },
-                fix,
-                messageId: MESSAGE_ID.NEWLINE_MISSING,
-              });
-            }
-            index += 1;
-          }
-
-          const attrLast = node.attributes[node.attributes.length - 1];
-          const closeStyleActual =
-            node.openEnd.loc.start.line === attrLast.loc.end.line
-              ? "sameline"
-              : "newline";
-          if (closeStyle !== closeStyleActual) {
+        let index = 0;
+        for (const attr of node.attributes) {
+          const attrPrevious = node.attributes[index - 1];
+          const relativeToNode = attrPrevious || node.openStart;
+          if (attr.loc.start.line === relativeToNode.loc.end.line) {
             return context.report({
               node,
               data: {
-                actual: closeStyleActual,
-                expected: closeStyle,
+                attrName: attr.key.value,
               },
               fix,
-              messageId: MESSAGE_ID.CLOSE_STYLE_WRONG,
+              messageId: MESSAGE_ID.NEWLINE_MISSING,
             });
           }
-        } else {
-          let expectedLastLineNum = node.openStart.loc.start.line;
-          for (const attr of node.attributes) {
-            if (shouldBeMultiline) {
-              expectedLastLineNum += 1;
-            }
-            if (attr.value) {
-              const valueLineSpan =
-                attr.value.loc.end.line - attr.value.loc.start.line;
-              expectedLastLineNum += valueLineSpan;
-            }
-          }
-          if (shouldBeMultiline && closeStyle === "newline") {
-            expectedLastLineNum += 1;
-          }
+          index += 1;
+        }
 
-          if (node.openEnd.loc.end.line !== expectedLastLineNum) {
-            return context.report({
-              node,
-              data: {
-                attrMin: `${attrMin}`,
-              },
-              fix,
-              messageId: MESSAGE_ID.NEWLINE_UNEXPECTED,
-            });
-          }
+        const attrLast = node.attributes[node.attributes.length - 1];
+        const closeStyleActual =
+          node.openEnd.loc.start.line === attrLast.loc.end.line
+            ? "sameline"
+            : "newline";
+        if (closeStyle !== closeStyleActual) {
+          return context.report({
+            node,
+            data: {
+              actual: closeStyleActual,
+              expected: closeStyle,
+            },
+            fix,
+            messageId: MESSAGE_ID.CLOSE_STYLE_WRONG,
+          });
         }
       },
     });

--- a/packages/eslint-plugin/tests/rules/attrs-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/attrs-newline.test.js
@@ -296,43 +296,6 @@ id="p"
       </p>`,
       errors: [{ messageId: "newlineMissing" }],
     },
-    ...closeStyles.map((closeStyle) => ({
-      code: `
-      <p class="foo"
-        >
-        <img />
-      </p>`,
-      options: [
-        {
-          closeStyle,
-          ifAttrsMoreThan: 1,
-        },
-      ],
-      output: `
-      <p class="foo">
-        <img />
-      </p>`,
-      errors: [{ messageId: "newlineUnexpected" }],
-    })),
-    ...closeStyles.map((closeStyle) => ({
-      code: `
-      <p
-        class="foo"
-        id="p">
-        <img />
-      </p>`,
-      options: [
-        {
-          closeStyle,
-          ifAttrsMoreThan: 2,
-        },
-      ],
-      output: `
-      <p class="foo" id="p">
-        <img />
-      </p>`,
-      errors: [{ messageId: "newlineUnexpected" }],
-    })),
   ],
 });
 

--- a/packages/eslint-plugin/tests/rules/attrs-newline.test.js
+++ b/packages/eslint-plugin/tests/rules/attrs-newline.test.js
@@ -220,6 +220,20 @@ ruleTester.run("attrs-newline", rule, {
         },
       ],
     },
+    {
+      code: `
+      <button
+        type="button"
+        class="app-button"
+        data-property
+      ></button>`,
+      options: [
+        {
+          closeStyle: "newline",
+          ifAttrsMoreThan: 3,
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -326,6 +340,20 @@ templateRuleTester.run("[template] attrs-newline", rule, {
   valid: [
     {
       code: `html\`<div class="foo"></div>\``,
+    },
+    {
+      code: `html\`
+        <button
+          type="button"
+          class="app-button"
+          data-property
+        ></button>
+      \``,
+      options: [
+        {
+          ifAttrsMoreThan: 3,
+        },
+      ],
     },
   ],
   invalid: [


### PR DESCRIPTION
Good day,

This PR closes #303 

It was pretty easy to do, as it's just removing the part of the code that is responsible for handling the "reverse" validation of fewer attributes.
Hope I didn't forget anything :)