### PR TITLE
docs: fix docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Contents
 
-- [Prerequisite](#prerequisite)
+- [Prerequisites](#ㅔrerequisites)
 - [Installation](#installation)
 - [Configuration](#configuration)
   - [Flat config](#flat-config)
@@ -11,7 +11,7 @@
 - [Lint HTML in JavaScript Template Literal](#lint-html-in-javascript-template-literals)
 - [Editor Configuration](#editor-configuration)
 
-## Prerequisite
+## Prerequisites
 
 - Node.js: `^12.22.0 || ^14.17.0 || >=16.0.0`.
 - ESLint: `>=6`.
@@ -191,7 +191,7 @@ module.exports = [
 
 ## Lint HTML in JavaScript Template Literals
 
-This plugin provides the ability to lint not only HTML files, but also HTML written in [JavaScript Template Literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
+This plugin allows you to lint not only HTML files but also HTML written in [JavaScript Template Literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
 You can set the [@html-eslint rules](./rules.md) in your settings to lint JavaScript code without any additional configuration.
 
 ```js,eslint.config.js
@@ -210,8 +210,8 @@ export default [
 ];
 ```
 
-Not all Template literals are recognized as HTML.
-There are two ways to get the plugin to recognize them as HTML.
+Not all template literals are recognized as HTML.
+There are two ways to make the plugin recognize them as HTML.
 
 ```js
 // 1. Tagged Templates with a function named `html`
@@ -221,7 +221,7 @@ html` <div style="${style}"></div>`;
 const code = /* html */ `<div style="${style}"></div>`;
 ```
 
-If you want to specify that linting should be done with keywords other than `html`, you can change the settings option.
+If you want to use keywords other than `html` for linting, you can configure the `settings` option.
 
 ```js
  {
@@ -244,7 +244,7 @@ If you want to specify that linting should be done with keywords other than `htm
 
 ### VSCode
 
-To get [vscode-eslint](https://github.com/microsoft/vscode-eslint) support, we need to add the following in vscode settings.
+To enable [vscode-eslint](https://github.com/microsoft/vscode-eslint) support, add the following to your VSCode settings.
 
 ```json,.vscode/settings.json
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Contents
 
-- [Prerequisites](#ㅔrerequisites)
+- [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Configuration](#configuration)
   - [Flat config](#flat-config)

--- a/docs/rules/attrs-newline.md
+++ b/docs/rules/attrs-newline.md
@@ -1,6 +1,6 @@
 # attrs-newline
 
-This rule enforces a newline between attributes, when more than a certain number of attributes is present.
+This rule enforces a newline between attributes when more than a certain number of attributes are present.
 
 ## How to use
 

--- a/docs/rules/element-newline.md
+++ b/docs/rules/element-newline.md
@@ -37,8 +37,8 @@ Examples of **correct** code for this rule:
 
 This rule has an object option:
 
-- `"skip"`: skips newline checking for the specified elements` children.
-- `"inline"`: instructs the linter that the specified elements can remain on the same line.
+- `"skip"`: Skips newline checking for the children of the specified elements.
+- `"inline"`: Instructs the linter that the specified elements can remain on the same line.
 
 ```ts
 //...

--- a/docs/rules/id-naming-convention.md
+++ b/docs/rules/id-naming-convention.md
@@ -1,6 +1,6 @@
 # id-naming-convention
 
-This rule enforces consistent naming convention for `id` attribute values.
+This rule enforces a consistent naming convention for `id` attribute values.
 
 ## How to use
 
@@ -14,7 +14,7 @@ module.exports = {
 
 ## Rule Details
 
-This rule supports 4 naming cases. `camelCase`, `snake_case`, `PascalCase`, `kebab-case` (default `snake_case`). It also supports `regex`, which allows you to configure a custom naming convention.
+This rule supports four naming conventions. `camelCase`, `snake_case`, `PascalCase`, `kebab-case` (default `snake_case`). It also supports `regex`, which allows you to define a custom naming convention.
 
 ### Options
 
@@ -22,7 +22,7 @@ This rule supports 4 naming cases. `camelCase`, `snake_case`, `PascalCase`, `keb
 - `"camelCase"`: Enforce camelCase format.
 - `"PascalCase"`: Enforce PascalCase format.
 - `"kebab-case"`: Enforce kebab-case format.
-- `"regex", { "pattern": "^my-regex$", "flags": "i" }`: Enforce a format defined by a custom regex (`flags` option is optional).
+- `"regex", { "pattern": "^my-regex$", "flags": "i" }`: Enforce a format defined by a custom regex. The `flags` option is optional.
 
 #### "snake_case" (default)
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -26,7 +26,7 @@ For 4-space indentation (default option):
 }
 ```
 
-Or For tabbed indentation:
+Or, for tabbed indentation:
 
 ```json
 {
@@ -61,7 +61,7 @@ If the option is number it means the number of spaces for indentation.
 }
 ```
 
-Examples of **incorrect** code for this rule with the `"2"` option:
+Examples of **incorrect** code for this rule with the `2` option:
 
 <!-- prettier-ignore -->
 ```html,incorrect
@@ -70,7 +70,7 @@ Examples of **incorrect** code for this rule with the `"2"` option:
 </html>
 ```
 
-Examples of **correct** code for this rule with the `"2"` option:
+Examples of **correct** code for this rule with the `2` option:
 
 ```html,correct
 <html>
@@ -80,7 +80,7 @@ Examples of **correct** code for this rule with the `"2"` option:
 
 #### tab
 
-If the option is `"tab"` it means using `tab` for indentation.
+If the option is `"tab"` it enforces tab-based indentation.
 
 ```json
 {
@@ -126,6 +126,6 @@ This rule has an object option:
 }
 ```
 
-- `Attribute` (default: 1): enforces indentation level for attributes. e.g. indent of 2 spaces with `Attribute` set to `2` will indent the attributes with `4` spaces (2 x 2).
+- `Attribute` (default: 1): Specifies the attribute indentation level. e.g. indent of 2 spaces with `Attribute` set to `2` will indent the attributes with `4` spaces (2 x 2).
 
-- `tagChildrenIndent` (default: `{}`): specifies the indent increment of the child tags of the specified tag. e.g. For example, `"tagChildrenIndent": { "html": 0 }` will set the `<html/>` tag children to 0 indent (2 x 0).
+- `tagChildrenIndent` (default: `{}`): Specifies the indent increment of the child tags of the specified tag. e.g. For example, `"tagChildrenIndent": { "html": 0 }` will set the `<html/>` tag children to 0 indent (2 x 0).

--- a/docs/rules/lowercase.md
+++ b/docs/rules/lowercase.md
@@ -1,6 +1,6 @@
 # lowercase
 
-This rule enforces to use lowercase for tag and attribute names.
+This rule enforces the use of lowercase for tag and attribute names.
 
 ## How to use
 

--- a/docs/rules/max-element-depth.md
+++ b/docs/rules/max-element-depth.md
@@ -1,12 +1,12 @@
 # max-element-depth
 
-This rule enforces element maximum depth.
+This rule enforces a maximum allowed depth for nested HTML elements.
 
 ## Why?
 
-Deeply nested HTML structures can be difficult to read and understand, making the code harder to maintain. A flatter structure is more intuitive for developers, reducing the likelihood of errors and improving collaboration.
+Deeply nested HTML structures are harder to read and understand, making the code more difficult to maintain. Flatter structures are more intuitive for developers, reducing the likelihood of errors and improving team collaboration.
 
-Deep nesting can increase the complexity of rendering for browsers. The browser's layout engine needs to compute styles and positions for all elements, and deeply nested structures can slow down this process, especially on resource-constrained devices.
+Deep nesting also increases rendering complexity for browsers. The browser’s layout engine must compute styles and positions for every element, and excessive nesting can slow this down — especially on resource-constrained devices.
 
 ## How to use
 

--- a/docs/rules/no-abstract-roles.md
+++ b/docs/rules/no-abstract-roles.md
@@ -1,6 +1,6 @@
 # no-abstract-roles
 
-This rule disallows use of abstract roles.
+This rule disallows the use of abstract ARIA roles.
 
 ## How to use
 
@@ -14,7 +14,9 @@ module.exports = {
 
 ## Rule Details
 
-This rule disallows the use of abstract roles.
+Abstract roles are part of the ARIA (Accessible Rich Internet Applications) specification, but they are not intended for direct use in HTML. Using these roles has no effect and may lead to accessibility issues.
+
+The following abstract roles are disallowed by this rule:
 
 - Abstract roles
   - command

--- a/docs/rules/no-accesskey-attrs.md
+++ b/docs/rules/no-accesskey-attrs.md
@@ -1,11 +1,12 @@
 # no-accesskey-attrs
 
-This rule disallows use of `accesskey` attributes.
+This rule disallows the use of the `accesskey` attributes.
 
 ## Why?
 
-`accesskey` attributes allow web developers to assign keyboard shortcuts to elements.
-Inconsistencies between keyboard shortcuts and keyboard commands used by screenreader and keyboard only users create accessibility complications so to avoid complications, access keys should not be used.
+The `accesskey` attribute allows developers to assign keyboard shortcuts to elements.
+However, these shortcuts can conflict with screen readers or keyboard-only navigation, leading to accessibility issues.
+To prevent such problems, the use of `accesskey` is discouraged.
 
 ## How to use
 

--- a/docs/rules/no-aria-hidden-body.md
+++ b/docs/rules/no-aria-hidden-body.md
@@ -1,6 +1,6 @@
 # no-aria-hidden-body
 
-This rule disallows the use of the`aria-hidden` attribute on the `body`.
+This rule disallows the use of the `aria-hidden` attribute on the `body`.
 
 ## Why?
 

--- a/docs/rules/no-aria-hidden-body.md
+++ b/docs/rules/no-aria-hidden-body.md
@@ -1,13 +1,12 @@
 # no-aria-hidden-body
 
-This rule disallows the use of `aria-hidden` attribute on the `body`.
+This rule disallows the use of the`aria-hidden` attribute on the `body`.
 
 ## Why?
 
-The `aria-hidden` attribute is typically used to hide elements from assistive technologies (such as screen readers) when they are not intended to be perceived by users.
+The `aria-hidden` attribute is used to hide elements from assistive technologies, such as screen readers, when the content should not be exposed to users.
 
-When `aria-hidden`="true" is applied to the `<body>` element, it removes the entire content of the document from the accessibility tree.
-This means that assistive technologies will not perceive any of the content within the `<body>`, making the entire page inaccessible to users who rely on screen readers or other assistive technologies.
+Applying` aria-hidden="true"` to the `<body>` element removes the entire page content from the accessibility tree, effectively making the page inaccessible to users who rely on assistive technologies.
 
 ## How to use
 
@@ -24,8 +23,8 @@ module.exports = {
 Examples of **incorrect** code for this rule:
 
 ```html,incorrect
-<body aria-hidden>
-  <body aria-hidden="true"></body>
+<body aria-hidden="true">
+  <div>Main content</div>
 </body>
 ```
 

--- a/docs/rules/no-aria-hidden-body.md
+++ b/docs/rules/no-aria-hidden-body.md
@@ -6,7 +6,7 @@ This rule disallows the use of the`aria-hidden` attribute on the `body`.
 
 The `aria-hidden` attribute is used to hide elements from assistive technologies, such as screen readers, when the content should not be exposed to users.
 
-Applying` aria-hidden="true"` to the `<body>` element removes the entire page content from the accessibility tree, effectively making the page inaccessible to users who rely on assistive technologies.
+Applying `aria-hidden="true"` to the `<body>` element removes the entire page content from the accessibility tree, effectively making the page inaccessible to users who rely on assistive technologies.
 
 ## How to use
 

--- a/docs/rules/no-duplicate-attrs.md
+++ b/docs/rules/no-duplicate-attrs.md
@@ -1,11 +1,11 @@
 # no-duplicate-attrs
 
-Disallow duplicate attributes.
+This rule disallows the use of duplicate attributes.
 
 ## Why?
 
-The HTML specification mandates that attribute names must be unique within a single HTML element.
-Violating this rule results in non-compliance with the standard.
+According to the HTML specification, each attribute name must be unique within a single element.
+Duplicate attributes are invalid and can lead to unexpected behavior in browsers.
 
 ## How to use
 

--- a/docs/rules/no-duplicate-id.md
+++ b/docs/rules/no-duplicate-id.md
@@ -2,6 +2,11 @@
 
 This rule disallows duplicate `id` attributes.
 
+## Why?
+
+In HTML, the id attribute must be unique within a document.
+Duplicate IDs can break CSS and JavaScript selectors and interfere with accessibility tools.
+
 ## How to use
 
 ```js,.eslintrc.js

--- a/docs/rules/no-extra-spacing-attrs.md
+++ b/docs/rules/no-extra-spacing-attrs.md
@@ -1,6 +1,6 @@
 # no-extra-spacing-attrs
 
-This rule disallows extra spaces around attributes, and/or between the tag start and end
+This rule disallows extra spaces around attributes and between the start or end of a tag.
 
 ## How to use
 
@@ -41,7 +41,7 @@ Examples of **correct** code for this rule:
 
 ## Options
 
-- `enforceBeforeSelfClose` (default: false): enforce one space before self closing (`/>`)
+- `enforceBeforeSelfClose` (default: false): Enforce exactly one space before self closing tag (`/>`)
 
 Examples of **incorrect** code for this rule with the default `{ "enforceBeforeSelfClose": true }` option:
 
@@ -65,7 +65,7 @@ Examples of **correct** code for this rule with the default `{ "enforceBeforeSel
 
 <!-- prettier-ignore-end -->
 
-- `disallowMissing` (default: false): Enforce at least one space between attributes
+- `disallowMissing` (default: false): Requires at least one space between attributes (no missing whitespace).
 
 Example(s) of **incorrect** code for this rule with the `{ "disallowMissing": true }` option:
 
@@ -89,7 +89,7 @@ Example(s) of **correct** code for this rule with the `{ "disallowMissing": true
 
 <!-- prettier-ignore-end -->
 
-- `disallowTabs` (default: false): Enforce using spaces instead of tabs between attributes
+- `disallowTabs` (default: false): Disallows tabs between attributes; enforces the use of spaces instead.
 
 Example(s) of **incorrect** code for this rule with the `{ "disallowTabs": true }` option:
 
@@ -113,7 +113,7 @@ Example(s) of **correct** code for this rule with the `{ "disallowTabs": true }`
 
 <!-- prettier-ignore-end -->
 
-- `disallowInAssignment` (default: false): Disallows spaces around the attribute assignment operator `=`
+- `disallowInAssignment` (default: false): Disallows spaces before or after the `=` in attribute assignments.
 
 Example(s) of **incorrect** code for this rule with the `{ "disallowInAssignment": true }` option:
 

--- a/docs/rules/no-extra-spacing-text.md
+++ b/docs/rules/no-extra-spacing-text.md
@@ -14,11 +14,11 @@ module.exports = {
 
 ## Rule Details
 
-[Whitespace in HTML is largely ignored](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace), so the purpose of this rule is to prevent unnecessary whitespace in text, such as:
+[Whitespace in HTML is largely ignored](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace), so the purpose of this rule is to prevent unnecessary whitespace in text and comments, such as:
 
-- Tab characters
-- Sequences of more than 1 whitespace character
-- Whitespace at the end of a line
+- Tab characters.
+- Sequences of two or more consecutive whitespace characters.
+- Whitespace at the end of a line.
 
 When used with `--fix`, the rule will replace invalid whitespace with a single space.
 
@@ -52,7 +52,7 @@ This rule has an object option:
 
 ```ts
 //...
-"@html-eslint/element-newline": ["error", {
+"@html-eslint/no-extra-spacing-text": ["error", {
   "skip": Array<string>
 }]
 ```

--- a/docs/rules/no-heading-inside-button.md
+++ b/docs/rules/no-heading-inside-button.md
@@ -27,5 +27,5 @@ Examples of **incorrect** code for this rule:
 Examples of **correct** code for this rule:
 
 ```html,correct
-<button><span>Click Me</h1></button>
+<button><span>Click Me</span></button>
 ```

--- a/docs/rules/no-heading-inside-button.md
+++ b/docs/rules/no-heading-inside-button.md
@@ -26,6 +26,6 @@ Examples of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-```html,incorrect
+```html,correct
 <button><span>Click Me</h1></button>
 ```

--- a/docs/rules/no-invalid-role.md
+++ b/docs/rules/no-invalid-role.md
@@ -1,17 +1,17 @@
 # no-invalid-role
 
-This rule disallows the use of invalid role on elements.
+This rule disallows the use of an invalid ARIA role on elements.
 
 ## Why?
 
-This rule checks for the following two cases
+This rule checks for the following two cases:
 
-1. If a role that doesn't exist in [this list](https://www.w3.org/TR/wai-aria/#roles_categorization) is used
+1. When a role not included in the [official ARIA role list](https://www.w3.org/TR/wai-aria/#roles_categorization) is used.
 
-1. If using `role="presentation"` or `role="none"` on certain HTML tags
+1. When `role="presentation"` or `role="none"` is used on certain HTML elements.
 
    - Certain HTML elements have built-in semantic roles that convey important meaning to assistive technologies (e.g., screen readers). Using `role="presentation"` or `role="none"` removes this meaning, making the content harder to interpret for users relying on assistive tools.
-   - Interactive elements, such as `<button>`, `<a>`, or `<input>`, are inherently focusable and actionable. Using role="presentation" or role="none" on these elements breaks their expected functionality and prevents users from interacting with them effectively.
+   - Interactive elements, such as `<button>`, `<a>`, or `<input>`, are inherently focusable and actionable. Applying `role="presentation"` or `role="none"` to these elements breaks their expected functionality and can make them unusable for assistive technology users.
 
 ## How to use
 

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -1,6 +1,6 @@
 # no-multiple-empty-lines
 
-This rule disallows use of multiple empty lines.
+This rule disallows the use of multiple consecutive empty lines.
 
 ## How to use
 
@@ -14,11 +14,11 @@ module.exports = {
 
 ## Rule Details
 
-This rule disallows the use of empty lines which exceeded the maximum lines allowed.
+This rule disallows consecutive empty lines that exceed the allowed maximum.
 
 ### Options
 
-- `max` (default 2): enforces a maximum number of consecutive empty lines.
+- `max` (default 2): Specifies the maximum number of consecutive empty lines allowed.
 
 Examples of **incorrect** code for this rule with the default `{ "max": 2 }` option:
 

--- a/docs/rules/no-multiple-h1.md
+++ b/docs/rules/no-multiple-h1.md
@@ -1,6 +1,6 @@
 # no-multiple-h1
 
-This rule disallows multiple `<h1>`.
+This rule disallows the use of multiple `<h1>`.
 
 ## How to use
 
@@ -14,7 +14,7 @@ module.exports = {
 
 ## Rule Details
 
-This rule disallows the use of multiple `<h1>` tags.
+This rule disallows the use of multiple `<h1>`.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-nested-interactive.md
+++ b/docs/rules/no-nested-interactive.md
@@ -1,6 +1,6 @@
 # no-nested-interactive
 
-This rule disallows interactive elements from being nested
+This rule disallows interactive elements from being nested within other interactive elements.
 
 ## Why?
 

--- a/docs/rules/no-non-scalable-viewport.md
+++ b/docs/rules/no-non-scalable-viewport.md
@@ -1,8 +1,8 @@
 # no-non-scalable-viewport
 
-This rule disallows use of `user-scalable=no` in `<meta name="viewport">`.
+This rule disallows the use of `user-scalable=no` in the `<meta name="viewport">`.
 
-The `user-scalable=no` disables zooming on a page. It makes users with partial vision or low vision hard to read web content.
+The `user-scalable=no` setting disables zooming on a page, which can make it difficult for users with partial or low vision to read the content.
 
 ## How to use
 

--- a/docs/rules/no-obsolete-tags.md
+++ b/docs/rules/no-obsolete-tags.md
@@ -1,11 +1,11 @@
 # no-obsolete-tags
 
-This rule disallows using obsolete tags in HTML5.
+This rule disallows the use of obsolete tags in HTML5.
 
 ## Why?
 
-The following element list is obsoleted in HTML5.
-It's not encouraged to use these tags.
+The following elements are obsoleted in HTML5.
+These tags are discouraged and should be avoided.
 
 ```plaintext
 applet, acronym, bgsound, dir, frame, frameset, noframes, isindex, keygen, listing, menuitem, nextid, noembed, plaintext, rb, rtc, strike, xmp, basefont, big, blink, center, font, marquee, multicol, nobr, spacer, tt

--- a/docs/rules/no-positive-tabindex.md
+++ b/docs/rules/no-positive-tabindex.md
@@ -1,10 +1,10 @@
 # no-positive-tabindex
 
-This rule disallows use of positive `tabindex` attribute.
+This rule disallows the use of positive `tabindex` attribute values.
 
 ## Why?
 
-n HTML, the `tabindex` attribute is used to specify the tab order of elements when navigating through a page using the "Tab" key.
+In HTML, the `tabindex` attribute is used to specify the tab order of elements when navigating through a page using the "Tab" key.
 By default, elements are included in the tab order based on their position in the HTML source code. The `tabindex` attribute allows you to modify this order.
 
 It's generally a good practice to let the natural flow of elements in the HTML dictate the tab order whenever possible.

--- a/docs/rules/no-restricted-attr-values.md
+++ b/docs/rules/no-restricted-attr-values.md
@@ -1,6 +1,6 @@
 # no-restricted-attr-values
 
-This rule disallows use of specified attribute values.
+This rule disallows the use of specified attribute values.
 
 ## How to use
 
@@ -22,11 +22,11 @@ This rule allows you to specify attribute values that you don't want to use in y
 
 ### Options
 
-This rule takes an array of option objects, where the `attrPatterns` and `attrValuePatterns` are specified.
+This rule takes an array of option objects. Each object can contain the following properties:
 
-- `attrPatterns`: an array of strings representing regular expression pattern, disallows attribute names that match any of the patterns.
-- `attrValuePatterns`: an array of strings representing regular expression pattern, disallows attribute values that match any of the patterns.
-- `message` (optional): a string for custom message.
+- `attrPatterns`: An array of strings, each representing a regular expression pattern. It disallows attribute names that match any of the patterns.
+- `attrValuePatterns`: An array of strings, each representing a regular expression pattern. It disallows attribute values that match any of the patterns.
+- `message` (optional): A custom error message to be shown when the rule is triggered.
 
 ```js
 module.exports = {

--- a/docs/rules/no-restricted-attrs.md
+++ b/docs/rules/no-restricted-attrs.md
@@ -1,6 +1,6 @@
 # no-restricted-attrs
 
-This rule disallows use of specified attributes.
+This rule disallows the use of specified attributes.
 
 ## How to use
 
@@ -27,9 +27,9 @@ This rule allows you to specify attributes that you don't want to use in your ap
 
 This rule takes an array of option objects, where the `tagPatterns` and `attrPatterns` are specified.
 
-- `tagPatterns`: an array of strings representing regular expression pattern, disallows tag name that match any of the patterns.
-- `attrPatterns`: an array of strings representing regular expression pattern, disallows attribute name that match any of the patterns.
-- `message` (optional): a string for custom message.
+- `tagPatterns`: An array of strings representing regular expression pattern. It disallows tag name that match any of the patterns.
+- `attrPatterns`: An array of strings representing regular expression pattern. It disallows attribute names that match any of the patterns.
+- `message` (optional): A custom error message to be shown when the rule is triggered.
 
 ```js
 module.exports = {

--- a/docs/rules/no-script-style-type.md
+++ b/docs/rules/no-script-style-type.md
@@ -1,10 +1,10 @@
 # no-script-style-type
 
-This rule disallows the use of `type` attributes for style sheets (unless not using CSS) and scripts (unless not using JavaScript).
+This rule disallows the use of `type` attributes for style sheets (unless not using CSS) and scripts (unless using a different language than CSS/JavaScript).
 
 ## Why?
 
-Specifying below tag's `type` attributes is not necessary as HTML5 implies `text/css` and `text/javascript` as defaults
+Specifying the `type` attributes on the following tags is unnecessary as HTML5 implies `text/css` and `text/javascript` as defaults.
 
 - script - `type="text/javascript"`
 - style, link - `type="text/css"`

--- a/docs/rules/no-skip-heading-levels.md
+++ b/docs/rules/no-skip-heading-levels.md
@@ -1,6 +1,6 @@
 # no-skip-heading-levels
 
-This rule disallows skipping heading levels.
+This rule disallows skipping heading levels in HTML documents, such as jumping from `<h1>` to `<h3>`
 
 ## How to use
 

--- a/docs/rules/no-target-blank.md
+++ b/docs/rules/no-target-blank.md
@@ -1,6 +1,6 @@
 # no-target-blank
 
-This rule disallows usage of unsafe `target='_blank'`.
+This rule disallows the use of `target="blank"` without `rel="noreferrer"`.
 
 ## How to use
 

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -1,6 +1,6 @@
 # no-trailing-spaces
 
-This rule disallows trailing white spaces at the end of lines.
+This rule disallows trailing whitespace at the end of lines.
 
 ## How to use
 

--- a/docs/rules/prefer-https.md
+++ b/docs/rules/prefer-https.md
@@ -1,6 +1,6 @@
 # prefer-https
 
-This rule enforces to use `HTTPS` for embedded resources (image, media, style sheet and script).
+This rule enforces the use of `HTTPS` for embedded resources (image, media, style sheet and script).
 
 ## Why?
 

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -1,6 +1,6 @@
 # quotes
 
-This rule enforces consistent quoting attributes with double(`"`) or single(`'`)
+This rule enforces enforces consistent use of quotes for attribute values (`'` or `"`).
 
 ## How to use
 
@@ -18,8 +18,8 @@ module.exports = {
 
 This rule has two options
 
-- `"double"` (default): requires the use of double quotes(`"`).
-- `"single"`: requires the use of single quotes(`'`)
+- `"double"` (default): Requires the use of double quotes(`"`).
+- `"single"`: Requires the use of single quotes(`'`)
 
 #### "double"
 

--- a/docs/rules/require-attrs.md
+++ b/docs/rules/require-attrs.md
@@ -1,6 +1,6 @@
 # require-attrs
 
-This rule enforces the use of tag with specified attributes.
+This rule enforces the use of tags with specified attributes.
 
 ## How to use
 
@@ -22,7 +22,7 @@ module.exports = {
 
 ### Options
 
-This rule takes a array of object which has tag name with attribute name.
+This rule takes an array of objects which has tag name with attribute name.
 
 ```js
 module.exports = {

--- a/docs/rules/require-button-type.md
+++ b/docs/rules/require-button-type.md
@@ -1,6 +1,6 @@
 # require-button-type
 
-This rule enforces to use of button element with a valid type attribute.(`"button"`, `"submit"`, `"reset"`)
+This rule enforces that `button` elements include a valid `type` attribute: `"button"`, `"submit"`, or `"reset"`
 
 ## How to use
 

--- a/docs/rules/require-doctype.md
+++ b/docs/rules/require-doctype.md
@@ -1,6 +1,6 @@
 # require-doctype
 
-This rule enforces to use `<!DOCTYPE html>` in the document.
+This rule enforces the use of `<!DOCTYPE html>` in the document.
 
 ## How to use
 

--- a/docs/rules/require-explicit-size.md
+++ b/docs/rules/require-explicit-size.md
@@ -1,6 +1,6 @@
 # require-explicit-size
 
-This rule enforces that some elements (img, iframe) have explicitly defined width and height attributes.
+This rule enforces that certain elements such as `img` and `iframe`, have explicitly defined width and height attributes.
 
 ## How to use
 
@@ -23,7 +23,7 @@ Examples of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-```html,incorrect
+```html,correct
 <img src="/my-image.png" width="400" height="300">
 <iframe src="/page" width="400" height="300"></iframe>
 ```
@@ -32,11 +32,11 @@ Examples of **correct** code for this rule:
 
 This rule has an object option:
 
-- `"allowClass"`: List of classes to allow even if no size is specified
-- `"allowId"`: List of IDs to allow even if size is not specified
+- `"allowClass"`: An array of class names. If an element has one of these classes, it will be exempt from this rule.
+- `"allowId"`: An array of IDs. If an element has one of these IDs, it will be exempt from this rule.
 
 ```ts
-"@html-eslint/element-newline": ["error", {
+"@html-eslint/require-explicit-size": ["error", {
   "allowClass": string[];
   "allowId": string[];
 }]

--- a/docs/rules/require-form-method.md
+++ b/docs/rules/require-form-method.md
@@ -1,6 +1,6 @@
 # require-form-method
 
-This rule enforces to use a valid `method` attribute on the `<form>`.
+This rule enforces the use a valid `method` attribute on `<form>` elements.
 
 ## Why?
 

--- a/docs/rules/require-frame-title.md
+++ b/docs/rules/require-frame-title.md
@@ -1,6 +1,6 @@
 # require-frame-title
 
-This rule enforces use of `title` attribute in `<frame>` and `<iframe>`.
+This rule enforces the use of `title` attribute on `<frame>` and `<iframe>`.
 
 ## Why?
 

--- a/docs/rules/require-img-alt.md
+++ b/docs/rules/require-img-alt.md
@@ -1,6 +1,6 @@
 # require-img-alt
 
-This rule enforces to use `alt` attribute in `img` tags.
+This rule enforces the use of `alt` attribute in `img` tags.
 
 ## Why?
 

--- a/docs/rules/require-input-label.md
+++ b/docs/rules/require-input-label.md
@@ -4,7 +4,7 @@ This rule enforces the presence of accessible labels for input elements such as 
 
 ## Why?
 
-- Labels improve accessibility for users of assistive technologies by ensuring that form controls are properly described.
+Labels improve accessibility for users of assistive technologies by ensuring that form controls are properly described.
 
 ## How to use
 

--- a/docs/rules/require-lang.md
+++ b/docs/rules/require-lang.md
@@ -1,6 +1,6 @@
 # require-lang
 
-This rule enforces `lang` attribute at `<html>` tag.
+This rule enforces the presence of the `lang` attribute on the `<html>` tag.
 
 ## Why?
 

--- a/docs/rules/require-li-container.md
+++ b/docs/rules/require-li-container.md
@@ -1,6 +1,6 @@
 # require-li-container
 
-This rule enforces `<li>` to be in `<ul>`, `<ol>` or `<menu>`.
+This rule enforces that `<li>` elements must be children of `<ul>`, `<ol>` or `<menu>`.
 
 ## Why?
 

--- a/docs/rules/require-meta-charset.md
+++ b/docs/rules/require-meta-charset.md
@@ -1,6 +1,6 @@
 # require-meta-charset
 
-This rule enforces to use `<meta charset="...">` in the `<head>`.
+This rule requires a `<meta charset="...">` tag within the `<head>`.
 
 ## Why?
 

--- a/docs/rules/require-meta-description.md
+++ b/docs/rules/require-meta-description.md
@@ -1,10 +1,10 @@
 # require-meta-description
 
-This rule enforces to use `<meta name="description" content="...">` tag in `<head></head>`.
+This rule requires a `<meta name="description">` tag within the `<head></head>`.
 
 ## Why?
 
-`<meta name="description" content="...">` tag, is used to provide a concise and accurate summary of a web page's content.
+`<meta name="description" content="...">` tag provides a concise and accurate summary of a web page's content.
 
 - **SEO**:
   - Search engines often use the meta description as a snippet in search results to give users a preview of the content on a page. A well-crafted and relevant meta description can improve click-through rates, as it provides users with a clear idea of what to expect on the page.

--- a/docs/rules/require-meta-viewport.md
+++ b/docs/rules/require-meta-viewport.md
@@ -1,11 +1,11 @@
 # require-meta-viewport
 
-This rule enforces to use `<meta name="viewport" content="..">` in the `<head>`.
+This rule enforces the use of `<meta name="viewport">` in the `<head>`.
 
 ## Why?
 
 Different browsers and devices may have default viewport settings.
-Explicitly setting the viewport properties using the `<meta name="viewport">` tag ensures a consistent and predictable display across various platforms.
+Including a `<meta name="viewport">` tag ensures a consistent and predictable layout across screen sizes and platforms.
 
 ## How to use
 

--- a/docs/rules/require-open-graph-protocol.md
+++ b/docs/rules/require-open-graph-protocol.md
@@ -1,6 +1,6 @@
 # require-open-graph-protocol
 
-This rule enforces to use specified meta tags for open graph protocol.
+This rule enforces the use of specified meta tags for open graph protocol.
 
 ## How to use
 

--- a/docs/rules/require-title.md
+++ b/docs/rules/require-title.md
@@ -1,6 +1,6 @@
 # require-title
 
-This rule enforces to use `<title>` tag in `<head>`.
+This rule enforces the use of `<title>` tag in the `<head>`.
 
 ## Why?
 
@@ -23,7 +23,7 @@ module.exports = {
 
 ## Rule Details
 
-This rule enforces `<title>` tag in the `<head>`.
+This rule enforces the use of `<title>` tag in the `<head>`.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/sort-attrs.md
+++ b/docs/rules/sort-attrs.md
@@ -1,6 +1,6 @@
 # sort-attrs
 
-This rule enforces attributes alphabetical sorting.
+This rule enforces alphabetical sorting of attributes.
 
 ## How to use
 
@@ -37,7 +37,7 @@ Examples of **correct** code for this rule:
 
 #### priority
 
-This option allows you to set an array of attributes key names.
+This option allows you to set an array of attributes keyㄴ.
 When `priority` is defined, the specified attributes are sorted to the front with the highest priority.
 
 The default value of `priority` is `["id", "type", "class", "style"]`.
@@ -54,7 +54,7 @@ Examples of **correct** code for this rule with the default options (`{ "priorit
 <button id="foo" type="submit" class="bar" style="background:red"></button>
 ```
 
-You can also set your own priority if then the default priority will be overwritten.
+You can also define your own priority. If set, it will override the default.
 
 Examples of **incorrect** code for this rule with the `{ "priority": ["id", "style"] }` option:
 


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: fixes #327

## Description
Fixed typos and grammar throughout the documentation in addition to those mentioned in the issue.
