### PR TITLE
fix: crash with template expression in no-trailing-spaces

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-trailing-spaces.test.js
+++ b/packages/eslint-plugin/tests/rules/no-trailing-spaces.test.js
@@ -87,6 +87,13 @@ templateRuleTester.run("[template] no-tailing-spaces", rule, {
 </div>\``,
     },
     {
+      code: `html\`<div>
+      \${(() => {
+    
+      })()      }
+</div>\``,
+    },
+    {
       code: `  
 html\`<div>
 </div>\``,
@@ -127,6 +134,44 @@ html\`<div>
           line: 3,
           column: 9,
           endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: `html\`<div id=\${foo}   
+>
+text
+</div>\``,
+      output: `html\`<div id=\${foo}
+>
+text
+</div>\``,
+      errors: [
+        {
+          messageId: "trailingSpace",
+          line: 1,
+          column: 20,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: `
+html\`<div id=\${foo}   
+>
+text
+</div>\``,
+      output: `
+html\`<div id=\${foo}
+>
+text
+</div>\``,
+      errors: [
+        {
+          messageId: "trailingSpace",
+          line: 2,
+          column: 20,
+          endColumn: 23,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-trailing-spaces.test.js
+++ b/packages/eslint-plugin/tests/rules/no-trailing-spaces.test.js
@@ -26,6 +26,9 @@ ruleTester.run("no-tailing-spaces", rule, {
       errors: [
         {
           messageId: "trailingSpace",
+          column: 12,
+          endColumn: 14,
+          line: 1,
         },
       ],
     },
@@ -35,6 +38,9 @@ ruleTester.run("no-tailing-spaces", rule, {
       errors: [
         {
           messageId: "trailingSpace",
+          column: 12,
+          endColumn: 14,
+          line: 1,
         },
       ],
     },
@@ -44,6 +50,9 @@ ruleTester.run("no-tailing-spaces", rule, {
       errors: [
         {
           messageId: "trailingSpace",
+          column: 6,
+          endColumn: 8,
+          line: 1,
         },
       ],
     },
@@ -77,6 +86,49 @@ templateRuleTester.run("[template] no-tailing-spaces", rule, {
       })()}
 </div>\``,
     },
+    {
+      code: `  
+html\`<div>
+</div>\``,
+    },
   ],
-  invalid: [],
+  invalid: [
+    {
+      code: `  
+html\`<div>  
+</div>\``,
+      output: `  
+html\`<div>
+</div>\``,
+      errors: [
+        {
+          messageId: "trailingSpace",
+        },
+      ],
+    },
+    {
+      code: "html`<div>  \n  text\n  </div>`",
+      output: "html`<div>\n  text\n  </div>`",
+      errors: [
+        {
+          messageId: "trailingSpace",
+          line: 1,
+          column: 11,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: "html`<div>\n  text\n  </div>   `",
+      output: "html`<div>\n  text\n  </div>`",
+      errors: [
+        {
+          messageId: "trailingSpace",
+          line: 3,
+          column: 9,
+          endColumn: 12,
+        },
+      ],
+    },
+  ],
 });


### PR DESCRIPTION
## Checklist
https://html-eslint.org/playground#eyJjb2RlIjoiaHRtbGA8ZGl2PiAgXG4gICAgICAgIDxzcGFuPlxuICAgIDwvc3Bhbj5cbiAgICA8L2Rpdj5cbmBcbiIsImNvbmZpZyI6eyJydWxlcyI6eyJAaHRtbC1lc2xpbnQvbm8tdHJhaWxpbmctc3BhY2VzIjoiZXJyb3IifX0sImxhbmd1YWdlIjoiamF2YXNjcmlwdCJ9

Fixed bug reporting incorrect location when used with template expression.

<img width="445" alt="스크린샷 2025-05-08 오전 12 40 01" src="https://github.com/user-attachments/assets/c2c5a5d9-29e9-4d0f-9a33-53bc5ba5dc6c" />



## Description
