### PR TITLE
fix: correct rule `require-open-graph-protocol` description

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -32,13 +32,13 @@
 
 ## SEO
 
-| Rule                                                             | Description                                            |     |
-| ---------------------------------------------------------------- | ------------------------------------------------------ | --- |
-| [no-multiple-h1](rules/no-multiple-h1)                           | Disallow multiple `<h1></h1>`.                         | ⭐  |
-| [require-lang](rules/require-lang)                               | Require `lang` attribute at `<html>` tag               | ⭐  |
-| [require-meta-description](rules/require-meta-description)       | Require use of `<meta name="description">` in `<head>` |     |
-| [require-open-graph-protocol](rules/require-open-graph-protocol) | Enforce to use `<meta name="viewport">` in `<head>`    |     |
-| [require-title](rules/require-title)                             | Require `<title><title/>` in the `<head><head/>`       | ⭐  |
+| Rule                                                             | Description                                                 |     |
+| ---------------------------------------------------------------- | ----------------------------------------------------------- | --- |
+| [no-multiple-h1](rules/no-multiple-h1)                           | Disallow multiple `<h1></h1>`.                              | ⭐  |
+| [require-lang](rules/require-lang)                               | Require `lang` attribute at `<html>` tag                    | ⭐  |
+| [require-meta-description](rules/require-meta-description)       | Require use of `<meta name="description">` in `<head>`      |     |
+| [require-open-graph-protocol](rules/require-open-graph-protocol) | Enforce to use specified meta tags for open graph protocol. |     |
+| [require-title](rules/require-title)                             | Require `<title><title/>` in the `<head><head/>`            | ⭐  |
 
 ## Accessibility
 

--- a/packages/eslint-plugin/lib/rules/require-open-graph-protocol.js
+++ b/packages/eslint-plugin/lib/rules/require-open-graph-protocol.js
@@ -42,7 +42,8 @@ module.exports = {
     type: "code",
 
     docs: {
-      description: 'Enforce to use `<meta name="viewport">` in `<head>`',
+      description:
+        "Enforce to use specified meta tags for open graph protocol.",
       category: RULE_CATEGORY.SEO,
       recommended: false,
     },


### PR DESCRIPTION
## Checklist

None.

## Description

This PR fixes the `meta.docs.description` property content of rule `require-open-graph-protocol`.