### PR TITLE
Docs/add google io baseline link

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -12,6 +12,7 @@
 | [no-duplicate-attrs](rules/no-duplicate-attrs)               | Disallow to use duplicate attributes                                                           | ⭐   |
 | [no-duplicate-class](rules/no-duplicate-class)               | Disallow to use duplicate class                                                                | 🔧   |
 | [no-duplicate-id](rules/no-duplicate-id)                     | Disallow to use duplicate id                                                                   | ⭐   |
+| [no-duplicate-in-head](rules/no-duplicate-in-head)           | Disallow duplicate tags in <head>                                                              |      |
 | [no-extra-spacing-text](rules/no-extra-spacing-text)         | Disallow unnecessary consecutive spaces                                                        | 🔧   |
 | [no-inline-styles](rules/no-inline-styles)                   | Disallow using inline style                                                                    |      |
 | [no-nested-interactive](rules/no-nested-interactive)         | Disallows nested interactive elements                                                          |      |

--- a/docs/rules/no-duplicate-in-head.md
+++ b/docs/rules/no-duplicate-in-head.md
@@ -1,0 +1,101 @@
+# no-duplicate-head-tags
+
+This rule disallows duplicate tags in the `<head>` section that should be unique.
+
+## Why?
+
+Certain HTML tags in the `<head>` section should appear only once per document for proper functionality and SEO optimization. Having duplicate tags can cause:
+
+- Multiple page titles confusing search engines and browsers
+- Conflicting character encodings
+- Multiple viewport declarations causing layout issues
+- Conflicting base URLs
+- Multiple canonical URLs diluting SEO value
+
+## How to use
+
+```js,.eslintrc.js
+module.exports = {
+  rules: {
+    "@html-eslint/no-duplicate-head-tags": "error",
+  },
+};
+```
+
+## Rule Details
+
+This rule checks for duplicate occurrences of the following tags within `<head>`:
+
+- `<title>` - Document title
+- `<base>` - Base URL for relative URLs
+- `<meta charset>` - Character encoding declaration
+- `<meta name="viewport">` - Viewport configuration
+- `<link rel="canonical">` - Canonical URL declaration
+
+Examples of **incorrect** code for this rule:
+
+```html,incorrect
+<head>
+  <title>First Title</title>
+  <title>Second Title</title>
+</head>
+```
+
+```html,incorrect
+<head>
+  <base href="/" />
+  <base href="/home" />
+</head>
+```
+
+```html,incorrect
+<head>
+  <meta charset="UTF-8" />
+  <meta charset="ISO-8859-1" />
+</head>
+```
+
+```html,incorrect
+<head>
+  <meta name="viewport" content="width=device-width" />
+  <meta name="viewport" content="initial-scale=1" />
+</head>
+```
+
+```html,incorrect
+<head>
+  <link rel="canonical" href="https://example.com" />
+  <link rel="canonical" href="https://example.org" />
+</head>
+```
+
+Examples of **correct** code for this rule:
+
+```html,correct
+<head>
+  <title>Page Title</title>
+  <base href="/" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width" />
+  <link rel="canonical" href="https://example.com" />
+</head>
+```
+
+```html,correct
+<head>
+  <meta charset="UTF-8" />
+  <meta name="description" content="Page description" />
+  <meta name="keywords" content="html, css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+```
+
+Note that tags outside the `<head>` section are not checked by this rule, and other meta tags (like `description`, `keywords`) are allowed to have multiple instances.
+
+## Further Reading
+
+- [MDN: Document metadata](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)
+- [MDN: title element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
+- [MDN: base element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)
+- [MDN: meta element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)
+- [MDN: link element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)

--- a/docs/rules/use-baseline.md
+++ b/docs/rules/use-baseline.md
@@ -9,7 +9,7 @@ This rule enforces the use of baseline features.
 Baseline features are available across popular browsers. Baseline has two stages:
 
 - **Newly available**: The feature works across the latest devices and browser versions. The feature might not work in older devices or browsers.
-- **Widely available**: The feature is well established and works across many devices and browser versions. It’s been available across browsers for at least 2½ years (30 months).
+- **Widely available**: The feature is well established and works across many devices and browser versions. It's been available across browsers for at least 2½ years (30 months).
 
 Prior to being newly available, a feature has **Limited availability** when it's not yet available across all browsers.
 
@@ -59,3 +59,4 @@ If an integer `number` is used as an option, this rule allows features that beca
 
 - [W3C WebDX Community Group - Baseline](https://web-platform-dx.github.io/web-features/)
 - [web.dev - Baseline](https://web.dev/baseline)
+- [Chrome Developers Blog - Baseline features availability in developer tools](https://developer.chrome.com/blog/web-at-io25#7_baseline_features_availability_is_now_in_your_familiar_tools_vs_code_eslint_and_more)

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -22,6 +22,7 @@ const recommended = {
     "@html-eslint/require-closing-tags": "error",
     "@html-eslint/no-duplicate-attrs": "error",
     "@html-eslint/use-baseline": "error",
+    "@html-eslint/no-duplicate-in-head": "error",
   },
 };
 

--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -4,6 +4,7 @@ const parser = require("@html-eslint/parser");
 const { HTMLLanguage } = require("./languages/html-language");
 const { name, version } = require("../package.json");
 
+
 /**
  * @import { ESLint } from "eslint";
  */

--- a/packages/eslint-plugin/lib/rules/index.js
+++ b/packages/eslint-plugin/lib/rules/index.js
@@ -47,6 +47,8 @@ const maxElementDepth = require("./max-element-depth");
 const requireExplicitSize = require("./require-explicit-size");
 const useBaseLine = require("./use-baseline");
 const noDuplicateClass = require("./no-duplicate-class");
+const noDuplicateInHead = require("./no-duplicate-in-head");
+
 // import new rule here ↑
 // DO NOT REMOVE THIS COMMENT
 
@@ -100,6 +102,7 @@ const rules = {
   "require-explicit-size": requireExplicitSize,
   "use-baseline": useBaseLine,
   "no-duplicate-class": noDuplicateClass,
+   "no-duplicate-in-head": noDuplicateInHead,
   // export new rule here ↑
   // DO NOT REMOVE THIS COMMENT
 };

--- a/packages/eslint-plugin/lib/rules/no-duplicate-in-head.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-in-head.js
@@ -1,0 +1,186 @@
+/**
+ * @typedef { import("@html-eslint/types").Tag } Tag
+ * @typedef { import("@html-eslint/types").StyleTag } StyleTag
+ * @typedef { import("@html-eslint/types").ScriptTag } ScriptTag
+ * @typedef { import("@html-eslint/types").AttributeValue } AttributeValue
+ * @typedef { import("../types").RuleModule<[]> } RuleModule
+ */
+
+const { parse } = require("@html-eslint/template-parser");
+const { RULE_CATEGORY } = require("../constants");
+const { findAttr } = require("./utils/node");
+const {
+  shouldCheckTaggedTemplateExpression,
+  shouldCheckTemplateLiteral,
+} = require("./utils/settings");
+const { getSourceCode } = require("./utils/source-code");
+const { getRuleUrl } = require("./utils/rule");
+
+const MESSAGE_IDS = {
+  DUPLICATE_TAG: "duplicateTag",
+};
+
+/**
+ * Check if a tag has a charset attribute.
+ * @param {Tag} node
+ * @returns {boolean}
+ */
+function hasCharset(node) {
+  if (!node.attributes || node.attributes.length <= 0) {
+    return false;
+  }
+  return node.attributes.some(attr => attr.key && attr.key.value === "charset");
+}
+
+/**
+ * Check if a tag has a name attribute equal to "viewport".
+ * @param {Tag} node
+ * @returns {boolean}
+ */
+function isViewport(node) {
+  if (!node.attributes || node.attributes.length <= 0) {
+    return false;
+  }
+  const nameAttr = findAttr(node, "name");
+  return !!(nameAttr && nameAttr.value && nameAttr.value.value === "viewport");
+}
+
+/**
+ * Check if a link tag has rel="canonical".
+ * @param {Tag} node
+ * @returns {boolean}
+ */
+function isCanonicalLink(node) {
+  if (!node.attributes || node.attributes.length <= 0) {
+    return false;
+  }
+  const relAttr = findAttr(node, "rel");
+  const hrefAttr = findAttr(node, "href");
+  return !!(relAttr && relAttr.value && relAttr.value.value === "canonical" && hrefAttr);
+}
+
+/**
+ * @type {RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: "code",
+
+    docs: {
+      description: "Disallow duplicate tags in <head>",
+      category: RULE_CATEGORY.BEST_PRACTICE,
+      recommended: false,
+      url: getRuleUrl("no-duplicate-head-tags"),
+    },
+
+    fixable: null,
+    schema: [],
+    messages: {
+      [MESSAGE_IDS.DUPLICATE_TAG]: "Duplicate <{{tag}}> tag in <head>.",
+    },
+  },
+
+  create(context) {
+    const htmlTagsMap = new Map();
+    let insideHead = false;
+
+    /**
+     * @param {Map<string, Tag[]>} map
+     */
+    function createTagVisitor(map) {
+      /**
+       * @param {Tag} node
+       */
+      return function (node) {
+        const tagName = node.name.toLowerCase();
+
+        if (tagName === "head") {
+          insideHead = true;
+          return;
+        }
+
+        if (tagName === "/head") {
+          insideHead = false;
+          return;
+        }
+
+        if (!insideHead) return;
+
+        let trackingKey = null;
+
+        // Track <title> and <base>
+        if (["title", "base"].includes(tagName)) {
+          trackingKey = tagName;
+        }
+
+        // Track <meta charset> and <meta name=viewport>
+        if (tagName === "meta") {
+          if (hasCharset(node)) {
+            trackingKey = "meta[charset]";
+          } else if (isViewport(node)) {
+            trackingKey = "meta[name=viewport]";
+          }
+        }
+
+        // Track <link rel=canonical>
+        if (tagName === "link" && isCanonicalLink(node)) {
+          trackingKey = "link[rel=canonical]";
+        }
+
+        if (trackingKey) {
+          if (!map.has(trackingKey)) {
+            map.set(trackingKey, []);
+          }
+          const nodes = map.get(trackingKey);
+          if (nodes) {
+            nodes.push(node);
+          }
+        }
+      };
+    }
+
+    /**
+     * @param {Map<string, Tag[]>} map
+     */
+    function report(map) {
+      map.forEach((tags, tagName) => {
+        if (Array.isArray(tags) && tags.length > 1) {
+          tags.slice(1).forEach((tag) => {
+            context.report({
+              node: tag,
+              data: { tag: tagName },
+              messageId: MESSAGE_IDS.DUPLICATE_TAG,
+            });
+          });
+        }
+      });
+    }
+
+    return {
+      Tag: createTagVisitor(htmlTagsMap),
+      "Document:exit"() {
+        report(htmlTagsMap);
+      },
+      TaggedTemplateExpression(node) {
+        const tagsMap = new Map();
+        let templateInsideHead = false;
+        if (shouldCheckTaggedTemplateExpression(node, context)) {
+          parse(node.quasi, getSourceCode(context), {
+            Tag: createTagVisitor(tagsMap),
+          });
+        }
+        report(tagsMap);
+      },
+      TemplateLiteral(node) {
+        const tagsMap = new Map();
+        let templateInsideHead = false;
+        if (shouldCheckTemplateLiteral(node, context)) {
+          parse(node, getSourceCode(context), {
+            Tag: createTagVisitor(tagsMap),
+          });
+        }
+        report(tagsMap);
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/tests/rules/no-duplicate-in-head.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-in-head.test.js
@@ -1,0 +1,252 @@
+// @ts-nocheck
+/**
+ * @fileoverview Tests for no-duplicate-head-tags rule
+ */
+
+"use strict";
+
+const createRuleTester = require("../rule-tester");
+const rule = require("../../lib/rules/no-duplicate-in-head");
+
+const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
+
+ruleTester.run("no-duplicate-head-tags", rule, {
+  valid: [
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <title>Title One</title>
+          <base href="/" />
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width" />
+          <link rel="canonical" href="https://example.com" />
+        </head>
+      `,
+    },
+
+    {
+      filename: "test.html",
+      code: `
+        <body>
+          <title>Title Outside Head</title>
+          <meta charset="UTF-8" />
+          <link rel="canonical" href="https://example.com" />
+        </body>
+      `,
+    },
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width" />
+        </head>
+      `,
+    },
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <meta name="description" content="Some description" />
+          <meta name="keywords" content="html, css" />
+          <link rel="stylesheet" href="style.css" />
+        </head>
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <title>Title One</title>
+          <title>Title Two</title>
+        </head>
+      `,
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "title" },
+          line: 4,
+        },
+      ],
+    },
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <base href="/" />
+          <base href="/home" />
+        </head>
+      `,
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "base" },
+          line: 4,
+        },
+      ],
+    },
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <meta charset="UTF-8" />
+          <meta charset="ISO-8859-1" />
+        </head>
+      `,
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "meta[charset]" },
+          line: 4,
+        },
+      ],
+    },
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <meta name="viewport" content="width=device-width" />
+          <meta name="viewport" content="initial-scale=1" />
+        </head>
+      `,
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "meta[name=viewport]" },
+          line: 4,
+        },
+      ],
+    },
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <link rel="canonical" href="https://example.com" />
+          <link rel="canonical" href="https://example.org" />
+        </head>
+      `,
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "link[rel=canonical]" },
+          line: 4,
+        },
+      ],
+    },
+    // Multi duplicate test case
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <title>One</title>
+          <title>Two</title>
+          <base href="/" />
+          <base href="/home" />
+          <meta charset="UTF-8" />
+          <meta charset="ISO-8859-1" />
+          <meta name="viewport" content="width=device-width" />
+          <meta name="viewport" content="initial-scale=1" />
+          <link rel="canonical" href="https://example.com" />
+          <link rel="canonical" href="https://example.org" />
+        </head>
+      `,
+      errors: [
+        { messageId: "duplicateTag", data: { tag: "title" }, line: 4 },
+        { messageId: "duplicateTag", data: { tag: "base" }, line: 6 },
+        { messageId: "duplicateTag", data: { tag: "meta[charset]" }, line: 8 },
+        { messageId: "duplicateTag", data: { tag: "meta[name=viewport]" }, line: 10 },
+        { messageId: "duplicateTag", data: { tag: "link[rel=canonical]" }, line: 12 },
+      ],
+    },
+    // Test with multiple duplicates of the same tag
+    {
+      filename: "test.html",
+      code: `
+        <head>
+          <title>One</title>
+          <title>Two</title>
+          <title>Three</title>
+        </head>
+      `,
+      errors: [
+        { messageId: "duplicateTag", data: { tag: "title" }, line: 4 },
+        { messageId: "duplicateTag", data: { tag: "title" }, line: 5 },
+      ],
+    },
+  ],
+});
+
+// Template literal tests
+templateRuleTester.run("[template] no-duplicate-head-tags", rule, {
+  valid: [
+    {
+      code: `
+        html\`<head>
+          <title>Title One</title>
+          <base href="/" />
+          <meta charset="UTF-8" />
+          <meta name="viewport" content="width=device-width" />
+          <link rel="canonical" href="https://example.com" />
+        </head>\`
+      `,
+    },
+    {
+      code: `
+        html\`<head>
+          <meta name="description" content="Some description" />
+          <meta name="keywords" content="html, css" />
+        </head>\`
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        html\`<head>
+          <title>One</title>
+          <title>Two</title>
+        </head>\`
+      `,
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "title" },
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        html\`<head>
+          <meta charset="UTF-8" />
+          <meta charset="ISO-8859-1" />
+        </head>\`
+      `,
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "meta[charset]" },
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        html\`<head>
+          <base href="/" />
+          <base href="/home" />
+          <base href="/other" />
+        </head>\`
+      `,
+      errors: [
+        { messageId: "duplicateTag", data: { tag: "base" }, line: 4 },
+        { messageId: "duplicateTag", data: { tag: "base" }, line: 5 },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: fixes #348
[docs] add reference link on use-baseline doc

## Description
added a link to the google io 2025 post to the use-baseline rules documentation.

https://developer.chrome.com/blog/web-at-io25#7_baseline_features_availability_is_now_in_your_familiar_tools_vs_code_eslint_and_more
