### PR TITLE
docs: fix typo in max-element-depth

### DIFF
--- a/docs/rules/max-element-depth.md
+++ b/docs/rules/max-element-depth.md
@@ -27,7 +27,7 @@ This rule has an object option:
 - `"max"`: Maximum element depth to allow.
 
 ```ts
-"@html-eslint/element-newline": ["error", {
+"@html-eslint/max-element-depth": ["error", {
   "max": number
 }]
 ```


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: fixes #000

## Description

Trivial typo