### PR TITLE
No empty headings rule

### DIFF
--- a/docs/rules/no-empty-headings.md
+++ b/docs/rules/no-empty-headings.md
@@ -1,0 +1,42 @@
+# no-empty-headings
+
+This rule enforces that all heading elements (h1–h6) and elements with `role="heading"` and `aria-level` must have accessible text content.
+
+### Why?
+
+Headings relay the structure of a webpage and provide a meaningful, hierarchical order of its content. If headings are empty or their text contents are inaccessible, this could confuse users or prevent them from accessing sections of interest, especially for those using assistive technology.
+
+## How to use
+
+```js,.eslintrc.js
+module.exports = {
+  rules: {
+    "@html-eslint/no-empty-headings": "error",
+  },
+};
+```
+
+## Rule Details
+
+Headings that are empty or whose text is only present in elements with `aria-hidden="true"` are not allowed, as this can confuse users or prevent them from accessing sections of interest.
+
+### ❌ Incorrect
+
+```html
+<h1></h1>
+<div role="heading" aria-level="1"></div>
+<h2><span aria-hidden="true">Inaccessible text</span></h2>
+```
+
+### ✅ Correct
+
+```html
+<h1>Heading Content</h1>
+<h2><span>Text</span></h2>
+<div role="heading" aria-level="1">Heading Content</div>
+<h3 aria-hidden="true">Heading Content</h3>
+<h4 hidden>Heading Content</h4>
+```
+
+### Resources
+- [ember-template-lint: no-empty-headings](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-empty-headings.md)

--- a/packages/eslint-plugin/lib/rules/index.js
+++ b/packages/eslint-plugin/lib/rules/index.js
@@ -48,6 +48,7 @@ const maxElementDepth = require("./max-element-depth");
 const requireExplicitSize = require("./require-explicit-size");
 const useBaseLine = require("./use-baseline");
 const noDuplicateClass = require("./no-duplicate-class");
+const noEmptyHeadings = require("./no-empty-headings");
 // import new rule here ↑
 // DO NOT REMOVE THIS COMMENT
 
@@ -102,6 +103,7 @@ const rules = {
   "require-explicit-size": requireExplicitSize,
   "use-baseline": useBaseLine,
   "no-duplicate-class": noDuplicateClass,
+  "no-empty-headings": noEmptyHeadings,
   // export new rule here ↑
   // DO NOT REMOVE THIS COMMENT
 };

--- a/packages/eslint-plugin/lib/rules/no-empty-headings.js
+++ b/packages/eslint-plugin/lib/rules/no-empty-headings.js
@@ -1,5 +1,7 @@
 /**
  * @typedef { import("../types").RuleModule<[]> } RuleModule
+ * @typedef { import("@html-eslint/types").Tag } Tag
+ * @typedef { import("@html-eslint/types").Text } Text
  */
 
 const { RULE_CATEGORY } = require("../constants");
@@ -15,7 +17,7 @@ const MESSAGE_IDS = {
 const HEADING_NAMES = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 
 /**
- * @param {any} node
+ * @param {Tag} node
  */
 function isAriaHidden(node) {
   const ariaHiddenAttr = findAttr(node, "aria-hidden");
@@ -23,7 +25,7 @@ function isAriaHidden(node) {
 }
 
 /**
- * @param {any} node
+ * @param {Tag} node
  * @returns {string}
  */
 function getHeadingText(node) {
@@ -45,23 +47,19 @@ function getHeadingText(node) {
  */
 function isRoleHeading(node) {
   const roleAttr = findAttr(node, "role");
-  const ariaLevel = findAttr(node, "aria-level");
   return (
     !!roleAttr &&
     !!roleAttr.value &&
-    roleAttr.value.value === "heading" &&
-    !!ariaLevel &&
-    !!ariaLevel.value &&
-    !!ariaLevel.value.value
+    roleAttr.value.value === "heading"
   );
 }
 
 /**
- * @param {any} node
+ * @param {Text | Tag} node
  * @returns {string}
  */
 function getAllText(node) {
-  if (!node.children) return "";
+  if (!isTag(node) || !node.children) return "";
   let text = "";
   for (const child of node.children) {
     if (isText(child)) {
@@ -74,11 +72,11 @@ function getAllText(node) {
 }
 
 /**
- * @param {any} node
+ * @param {Text | Tag} node
  * @returns {string}
  */
 function getAccessibleText(node) {
-  if (!node.children) return "";
+  if (!isTag(node) || !node.children) return "";
   let text = "";
   for (const child of node.children) {
     if (isText(child)) {
@@ -112,7 +110,7 @@ module.exports = {
   create(context) {
     return createVisitors(context, {
       Tag(node) {
-        const tagName = node.name && node.name.toLowerCase();
+        const tagName = node.name.toLowerCase();
         const isHeadingTag = HEADING_NAMES.has(tagName);
         const isRoleHeadingEl = isRoleHeading(node);
         if (!isHeadingTag && !isRoleHeadingEl) return;

--- a/packages/eslint-plugin/lib/rules/no-empty-headings.js
+++ b/packages/eslint-plugin/lib/rules/no-empty-headings.js
@@ -1,0 +1,140 @@
+/**
+ * @typedef { import("../types").RuleModule<[]> } RuleModule
+ */
+
+const { RULE_CATEGORY } = require("../constants");
+const { findAttr, isTag, isText } = require("./utils/node");
+const { createVisitors } = require("./utils/visitors");
+const { getRuleUrl } = require("./utils/rule");
+
+const MESSAGE_IDS = {
+  EMPTY_HEADING: "emptyHeading",
+  INACCESSIBLE_HEADING: "inaccessibleHeading",
+};
+
+const HEADING_NAMES = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
+
+/**
+ * @param {any} node
+ */
+function isAriaHidden(node) {
+  const ariaHiddenAttr = findAttr(node, "aria-hidden");
+  return ariaHiddenAttr && ariaHiddenAttr.value && ariaHiddenAttr.value.value === "true";
+}
+
+/**
+ * @param {any} node
+ * @returns {string}
+ */
+function getHeadingText(node) {
+  if (!node.children) return "";
+  let text = "";
+  for (const child of node.children) {
+    if (isText(child)) {
+      text += child.value.trim();
+    } else if (isTag(child) && !isAriaHidden(child)) {
+      text += getHeadingText(child);
+    }
+  }
+  return text;
+}
+
+/**
+ * @param {any} node
+ * @returns {boolean}
+ */
+function isRoleHeading(node) {
+  const roleAttr = findAttr(node, "role");
+  const ariaLevel = findAttr(node, "aria-level");
+  return (
+    !!roleAttr &&
+    !!roleAttr.value &&
+    roleAttr.value.value === "heading" &&
+    !!ariaLevel &&
+    !!ariaLevel.value &&
+    !!ariaLevel.value.value
+  );
+}
+
+/**
+ * @param {any} node
+ * @returns {string}
+ */
+function getAllText(node) {
+  if (!node.children) return "";
+  let text = "";
+  for (const child of node.children) {
+    if (isText(child)) {
+      text += child.value.trim();
+    } else if (isTag(child)) {
+      text += getAllText(child);
+    }
+  }
+  return text;
+}
+
+/**
+ * @param {any} node
+ * @returns {string}
+ */
+function getAccessibleText(node) {
+  if (!node.children) return "";
+  let text = "";
+  for (const child of node.children) {
+    if (isText(child)) {
+      text += child.value.trim();
+    } else if (isTag(child) && !isAriaHidden(child)) {
+      text += getAccessibleText(child);
+    }
+  }
+  return text;
+}
+
+/**
+ * @type {RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: "code",
+    docs: {
+      description: "Disallow empty or inaccessible headings.",
+      category: RULE_CATEGORY.ACCESSIBILITY,
+      recommended: false,
+      url: getRuleUrl("no-empty-headings"),
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      [MESSAGE_IDS.EMPTY_HEADING]: "Headings must not be empty.",
+      [MESSAGE_IDS.INACCESSIBLE_HEADING]: "Heading text is inaccessible to assistive technology.",
+    },
+  },
+  create(context) {
+    return createVisitors(context, {
+      Tag(node) {
+        const tagName = node.name && node.name.toLowerCase();
+        const isHeadingTag = HEADING_NAMES.has(tagName);
+        const isRoleHeadingEl = isRoleHeading(node);
+        if (!isHeadingTag && !isRoleHeadingEl) return;
+        
+        // Gather all text (including aria-hidden)
+        const allText = getAllText(node);
+        if (!allText) {
+          context.report({
+            node,
+            messageId: MESSAGE_IDS.EMPTY_HEADING,
+          });
+          return;
+        }
+        // Gather accessible text (not aria-hidden)
+        const accessibleText = getAccessibleText(node);
+        if (!accessibleText) {
+          context.report({
+            node,
+            messageId: MESSAGE_IDS.INACCESSIBLE_HEADING,
+          });
+        }
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin/tests/rules/no-empty-headings.test.js
+++ b/packages/eslint-plugin/tests/rules/no-empty-headings.test.js
@@ -1,0 +1,73 @@
+const createRuleTester = require("../rule-tester");
+const rule = require("../../lib/rules/no-empty-headings");
+
+const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
+
+ruleTester.run("no-empty-headings", rule, {
+  valid: [
+    { code: '<h1>Heading Content</h1>' },
+    { code: '<h2><span>Text</span></h2>' },
+    { code: '<div role="heading" aria-level="1">Heading Content</div>' },
+    { code: '<h3 aria-hidden="true">Heading Content</h3>' },
+    { code: '<h4 hidden>Heading Content</h4>' },
+    { code: '<h2><span aria-hidden="true"></span>Visible</h2>' },
+    { code: '<h2><span aria-hidden="true">Hidden</span><span>Visible</span></h2>' },
+  ],
+  invalid: [
+    {
+      code: '<h1></h1>',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<div role="heading" aria-level="1"></div>',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<h2><span aria-hidden="true">Inaccessible text</span></h2>',
+      errors: [{ messageId: 'inaccessibleHeading' }],
+    },
+    {
+      code: '<h3>   </h3>',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: '<h4><span aria-hidden="true"></span></h4>',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-empty-headings", rule, {
+  valid: [
+    { code: 'html`<h1>Heading Content</h1>`' },
+    { code: 'html`<h2><span>Text</span></h2>`' },
+    { code: 'html`<div role="heading" aria-level="1">Heading Content</div>`' },
+    { code: 'html`<h3 aria-hidden="true">Heading Content</h3>`' },
+    { code: 'html`<h4 hidden>Heading Content</h4>`' },
+    { code: 'html`<h2><span aria-hidden="true"></span>Visible</h2>`' },
+    { code: 'html`<h2><span aria-hidden="true">Hidden</span><span>Visible</span></h2>`' },
+  ],
+  invalid: [
+    {
+      code: 'html`<h1></h1>`',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: 'html`<div role="heading" aria-level="1"></div>`',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: 'html`<h2><span aria-hidden="true">Inaccessible text</span></h2>`',
+      errors: [{ messageId: 'inaccessibleHeading' }],
+    },
+    {
+      code: 'html`<h3>   </h3>`',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+    {
+      code: 'html`<h4><span aria-hidden="true"></span></h4>`',
+      errors: [{ messageId: 'emptyHeading' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Checklist
- [x] Adds the `no-empty-headings` rule
- [x] Includes tests for empty and inaccessible headings
- [x] Updates documentation with rule details and examples
- [x] All tests pass locally

- Addresses an existing open issue: fixes #355 

## Description
Implements the `no-empty-headings` rule to disallow empty or inaccessible headings (h1–h6, or elements with role="heading" and aria-level).
