### PR TITLE
Create group-attrs rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -68,6 +68,7 @@
 | -------------------------------------------------------- | ----------------------------------------------------------------- | ---- |
 | [attrs-newline](rules/attrs-newline)                     | Enforce newline between attributes                                | ⭐🔧 |
 | [element-newline](rules/element-newline)                 | Enforce newline between elements.                                 | ⭐🔧 |
+| [group-attrs](rules/group-attrs)                         | Enforce grouping and ordering of related attributes               | 🔧   |
 | [id-naming-convention](rules/id-naming-convention)       | Enforce consistent naming id attributes                           |      |
 | [indent](rules/indent)                                   | Enforce consistent indentation                                    | ⭐🔧 |
 | [lowercase](rules/lowercase)                             | Enforce to use lowercase for tag and attribute names.             | 🔧   |

--- a/docs/rules/group-attrs.md
+++ b/docs/rules/group-attrs.md
@@ -1,0 +1,148 @@
+# group-attrs
+
+Enforce grouping and ordering of related attributes.
+
+## How to use
+
+```js,.eslintrc.js
+module.exports = {
+  rules: {
+    "@html-eslint/group-attrs": "error",
+  },
+};
+```
+
+## Rule Details
+
+This rule ensures that related attributes are placed next to each other when multiple attributes from the same group are present on an element. It also ensures that attributes are in the correct order within their group.
+
+If only some attributes from a group are present (partial groups), they are still grouped together. For example, if you have a group `["left", "top", "right", "bottom"]` and only `left` and `top` are present, they should be adjacent to each other.
+
+Examples of **incorrect** code for this rule:
+
+```html
+<!-- min and max are separated by type -->
+<input min="5" type="text" max="10">
+
+<!-- width and height are separated by src and alt -->
+<img width="100" src="image.jpg" height="200" alt="Image">
+
+<!-- minlength and maxlength are separated by placeholder -->
+<textarea minlength="10" placeholder="Enter text" maxlength="100"></textarea>
+
+<!-- aria-labelledby and aria-describedby are separated by class -->
+<div aria-labelledby="label1" class="container" aria-describedby="desc1"></div>
+
+<!-- Partial groups: only some attributes from a group are present, but separated -->
+<div left="10" class="box" top="20"></div>
+
+<!-- Multiple attributes from positioning group separated -->
+<div left="0" width="100" top="10" height="50" right="100"></div>
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<!-- Related attributes are grouped together -->
+<input min="5" max="10" type="text">
+
+<!-- Related attributes are grouped together -->
+<img width="100" height="200" src="image.jpg" alt="Image">
+
+<!-- Related attributes are grouped together -->
+<textarea minlength="10" maxlength="100" placeholder="Enter text"></textarea>
+
+<!-- Related attributes are grouped together -->
+<div aria-labelledby="label1" aria-describedby="desc1" class="container"></div>
+
+<!-- Partial groups: multiple attributes from the same group are together -->
+<div left="10" top="20" class="box"></div>
+
+<!-- Multiple positioning attributes grouped together -->
+<div left="0" top="10" right="100" width="100" height="50"></div>
+
+<!-- Only one attribute from a group (no violation) -->
+<input min="5" type="text">
+
+<!-- No related attributes present -->
+<input type="text" name="example">
+```
+
+### Options
+
+This rule accepts an options object with the following properties:
+
+- `groups`: Array of attribute groups that should be kept together and in order.
+
+```ts
+//...
+"@html-eslint/group-attrs": ["error", {
+  "groups": Array<Array<string>>
+}]
+```
+
+#### groups
+
+Default:
+
+```js
+[
+  ["min", "max"],
+  ["minlength", "maxlength"], 
+  ["width", "height"],
+  ["aria-labelledby", "aria-describedby"],
+  ["data-min", "data-max"],
+  ["left", "top", "right", "bottom"]
+]
+```
+
+Defines arrays of attribute names that should be grouped together when present.
+
+Example configuration:
+
+```js,.eslintrc.js
+module.exports = {
+  rules: {
+    "@html-eslint/group-attrs": [
+      "error",
+      {
+        groups: [
+          ["min", "max"],
+          ["data-start", "data-end"],
+          ["x", "y"],
+          ["left", "top", "right", "bottom"]
+        ]
+      }
+    ],
+  },
+};
+```
+
+With this configuration:
+
+```html
+<!-- ❌ Incorrect: data-start and data-end are separated -->
+<div data-start="0" class="slider" data-end="100"></div>
+
+<!-- ✅ Correct: data-start and data-end are grouped -->
+<div data-start="0" data-end="100" class="slider"></div>
+
+<!-- ❌ Incorrect: x and y are separated -->
+<rect x="10" fill="red" y="20"></rect>
+
+<!-- ✅ Correct: x and y are grouped -->
+<rect x="10" y="20" fill="red"></rect>
+
+<!-- ❌ Incorrect: partial group separated (only 3 out of 4 positioning attributes) -->
+<div left="0" width="100" top="10" right="100"></div>
+
+<!-- ✅ Correct: partial group together -->
+<div left="0" top="10" right="100" width="100"></div>
+```
+
+## When Not To Use It
+
+You might want to disable this rule if:
+
+- You have `@html-eslint/sort-attrs` enabled
+- You have specific semantic groupings that don't align with the default groups

--- a/packages/eslint-plugin/lib/rules/group-attrs.js
+++ b/packages/eslint-plugin/lib/rules/group-attrs.js
@@ -1,0 +1,232 @@
+/**
+ * @import {Attribute} from "@html-eslint/types";
+ * @import {RuleModule} from "../types";
+ *
+ * @typedef {Object} Option
+ * @property {string[][]} [Option.groups] - Array of attribute groups that should be kept together and in order
+ */
+
+const { RULE_CATEGORY } = require("../constants");
+const { createVisitors } = require("./utils/visitors");
+const { getRuleUrl } = require("./utils/rule");
+const { getSourceCode } = require("./utils/source-code");
+
+const MESSAGE_IDS = {
+  NOT_GROUPED: "notGrouped",
+  WRONG_ORDER: "wrongOrder",
+};
+
+/**
+ * Default attribute groups that are commonly related.
+ * When multiple attributes from the same group are present,
+ * they should be placed next to each other in the specified order.
+ */
+const DEFAULT_GROUPS = [
+  ["min", "max"],
+  ["minlength", "maxlength"],
+  ["width", "height"],
+  ["aria-labelledby", "aria-describedby"],
+  ["data-min", "data-max"],
+  ["left", "top", "right", "bottom"],
+];
+
+/**
+ * @type {RuleModule<[Option]>}
+ */
+module.exports = {
+  meta: {
+    type: "code",
+
+    docs: {
+      description: "Enforce grouping and ordering of related attributes",
+      category: RULE_CATEGORY.STYLE,
+      recommended: false,
+      url: getRuleUrl("group-attrs"),
+    },
+
+    fixable: "code",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          groups: {
+            type: "array",
+            items: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+              minItems: 2,
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      [MESSAGE_IDS.NOT_GROUPED]: 
+        "Related attributes should be grouped together: {{attrs}} (found separated by: {{separator}})",
+      [MESSAGE_IDS.WRONG_ORDER]:
+        "Related attributes should be in the correct order: {{attrs}} (expected order: {{expectedOrder}})",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0] || {};
+    const groups = options.groups || DEFAULT_GROUPS;
+
+    /**
+     * @param {Attribute[]} attributes
+     */
+    function checkAttributes(attributes) {
+      if (attributes.length <= 1) {
+        return;
+      }
+
+      for (const group of groups) {
+        /** @type {string[]} */
+        const foundAttrs = [];
+        /** @type {number[]} */
+        const indices = [];
+        
+        // Find which attributes from this group are present
+        for (let i = 0; i < attributes.length; i++) {
+          const attr = attributes[i];
+          if (group.includes(attr.key.value)) {
+            foundAttrs.push(attr.key.value);
+            indices.push(i);
+          }
+        }
+        
+        // If we have multiple attributes from this group, check violations
+        if (foundAttrs.length > 1) {
+          const firstIndex = indices[0];
+          const lastIndex = indices[indices.length - 1];
+          
+          // Check if indices are consecutive
+          const isConsecutive = indices.every((index, i) => 
+            i === 0 || index === indices[i - 1] + 1
+          );
+          
+          if (!isConsecutive) {
+            // Grouping violation: attributes are not together
+            const separatorAttrs = [];
+            for (let i = firstIndex + 1; i < lastIndex; i++) {
+              if (!indices.includes(i)) {
+                separatorAttrs.push(attributes[i].key.value);
+              }
+            }
+            
+            context.report({
+              loc: {
+                start: attributes[firstIndex].loc.start,
+                end: attributes[lastIndex].loc.end,
+              },
+              messageId: MESSAGE_IDS.NOT_GROUPED,
+              data: {
+                attrs: foundAttrs.join(", "),
+                separator: separatorAttrs.join(", "),
+              },
+              fix(fixer) {
+                return fixAttributeOrder(fixer, attributes, indices, group, foundAttrs);
+              },
+            });
+            return; // Only report one violation at a time
+          } else {
+            // Check ordering violation: attributes are together but in wrong order
+            const expectedOrder = group.filter(attr => foundAttrs.includes(attr));
+            const isCorrectOrder = foundAttrs.every((attr, i) => attr === expectedOrder[i]);
+            
+            if (!isCorrectOrder) {
+              context.report({
+                loc: {
+                  start: attributes[firstIndex].loc.start,
+                  end: attributes[lastIndex].loc.end,
+                },
+                messageId: MESSAGE_IDS.WRONG_ORDER,
+                data: {
+                  attrs: foundAttrs.join(", "),
+                  expectedOrder: expectedOrder.join(", "),
+                },
+                fix(fixer) {
+                  return fixAttributeOrder(fixer, attributes, indices, group, foundAttrs);
+                },
+              });
+              return; // Only report one violation at a time
+            }
+          }
+        }
+      }
+    }
+
+    /**
+     * Fix attribute order by grouping and sorting them correctly
+     * @param {*} fixer
+     * @param {Attribute[]} attributes
+     * @param {number[]} indices
+     * @param {string[]} group
+     * @param {string[]} foundAttrs
+     */
+    function fixAttributeOrder(fixer, attributes, indices, group, foundAttrs) {
+      const sourceCode = getSourceCode(context);
+      const source = sourceCode.getText();
+      
+      // Get the attributes that need to be reordered
+      const attrsToReorder = indices.map(i => attributes[i]);
+      
+      // Sort them according to the group order
+      const expectedOrder = group.filter(attr => foundAttrs.includes(attr));
+      attrsToReorder.sort((a, b) => {
+        const aIndex = expectedOrder.indexOf(a.key.value);
+        const bIndex = expectedOrder.indexOf(b.key.value);
+        return aIndex - bIndex;
+      });
+      
+             // Create a fixed version of all attributes by building the new arrangement
+       const fixed = [];
+       let groupInserted = false;
+       const targetInsertIndex = Math.min(...indices); // Insert grouped attrs at position of first occurrence
+       
+       for (let i = 0; i < attributes.length; i++) {
+         if (i === targetInsertIndex && !groupInserted) {
+           // Insert the grouped/reordered attributes at the position of first occurrence
+           fixed.push(...attrsToReorder);
+           groupInserted = true;
+         } else if (!indices.includes(i)) {
+           // Only add non-grouped attributes
+           fixed.push(attributes[i]);
+         }
+         // Skip attributes that are part of the group (they're already inserted above)
+       }
+      
+      // Build the replacement text
+      let result = "";
+      for (let i = 0; i < fixed.length; i++) {
+        const attr = fixed[i];
+        result += source.slice(attr.range[0], attr.range[1]);
+        
+        // Add spacing between attributes
+        if (i < fixed.length - 1) {
+          result += " ";
+        }
+      }
+      
+      return fixer.replaceTextRange(
+        [attributes[0].range[0], attributes[attributes.length - 1].range[1]],
+        result
+      );
+    }
+
+    return createVisitors(context, {
+      Tag(node) {
+        checkAttributes(node.attributes);
+      },
+      ScriptTag(node) {
+        checkAttributes(node.attributes);
+      },
+      StyleTag(node) {
+        checkAttributes(node.attributes);
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin/lib/rules/index.js
+++ b/packages/eslint-plugin/lib/rules/index.js
@@ -51,6 +51,7 @@ const noDuplicateClass = require("./no-duplicate-class");
 const noEmptyHeadings = require("./no-empty-headings");
 const noInvalidEntity = require("./no-invalid-entity");
 const noDuplicateInHead = require("./no-duplicate-in-head");
+const groupAttrs = require("./group-attrs");
 // import new rule here ↑
 // DO NOT REMOVE THIS COMMENT
 
@@ -108,6 +109,7 @@ const rules = {
   "no-empty-headings": noEmptyHeadings,
   "no-invalid-entity": noInvalidEntity,
   "no-duplicate-in-head": noDuplicateInHead,
+  "group-attrs": groupAttrs,
   // export new rule here ↑
   // DO NOT REMOVE THIS COMMENT
 };

--- a/packages/eslint-plugin/tests/rules/group-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/group-attrs.test.js
@@ -1,0 +1,244 @@
+const createRuleTester = require("../rule-tester");
+const rule = require("../../lib/rules/group-attrs");
+
+const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
+
+ruleTester.run("group-attrs", rule, {
+  valid: [
+    // Basic valid cases
+    {
+      code: '<input min="5" max="10">',
+    },
+    {
+      code: '<div width="100" height="200">',
+    },
+    {
+      code: '<textarea minlength="5" maxlength="100">',
+    },
+    
+    // Only one attribute from a group
+    {
+      code: '<input min="5">',
+    },
+    {
+      code: '<input max="10">',
+    },
+    {
+      code: '<div width="100">',
+    },
+    
+    // No related attributes
+    {
+      code: '<input type="text" name="test">',
+    },
+    {
+      code: '<div class="test" id="example">',
+    },
+    
+    // Custom groups configuration
+    {
+      code: '<input data-start="1" data-end="10">',
+      options: [{ groups: [["data-start", "data-end"]] }],
+    },
+    
+    // Partial groups - only some attributes from a group present
+    {
+      code: '<div left="10" top="20">',
+    },
+    {
+      code: '<div left="10" top="20" class="test">',
+    },
+    {
+      code: '<input min="5" class="field">',
+    },
+    
+    // Empty attributes
+    {
+      code: '<div></div>',
+    },
+    
+    // Single attribute
+    {
+      code: '<input type="text">',
+    },
+  ],
+  invalid: [
+    // Basic min/max separation
+    {
+      code: '<input min="5" type="text" max="10">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "min, max",
+            separator: "type",
+          },
+        },
+      ],
+      output: '<input min="5" max="10" type="text">',
+    },
+    
+    // Wrong order within group
+    {
+      code: '<input max="10" min="5">',
+      errors: [
+        {
+          messageId: "wrongOrder",
+          data: {
+            attrs: "max, min",
+            expectedOrder: "min, max",
+          },
+        },
+      ],
+      output: '<input min="5" max="10">',
+    },
+    
+    // minlength/maxlength separation
+    {
+      code: '<textarea minlength="5" placeholder="Enter text" maxlength="100">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "minlength, maxlength",
+            separator: "placeholder",
+          },
+        },
+      ],
+      output: '<textarea minlength="5" maxlength="100" placeholder="Enter text">',
+    },
+    
+    // width/height separation
+    {
+      code: '<img width="100" src="test.jpg" height="200" alt="Test">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "width, height",
+            separator: "src",
+          },
+        },
+      ],
+      output: '<img width="100" height="200" src="test.jpg" alt="Test">',
+    },
+    
+    // Multiple separators
+    {
+      code: '<input min="5" type="text" name="test" max="10">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "min, max",
+            separator: "type, name",
+          },
+        },
+      ],
+      output: '<input min="5" max="10" type="text" name="test">',
+    },
+    
+    // aria attributes separation
+    {
+      code: '<div aria-labelledby="label1" class="test" aria-describedby="desc1">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "aria-labelledby, aria-describedby",
+            separator: "class",
+          },
+        },
+      ],
+      output: '<div aria-labelledby="label1" aria-describedby="desc1" class="test">',
+    },
+    
+    // Custom groups
+    {
+      code: '<input data-start="1" type="text" data-end="10">',
+      options: [{ groups: [["data-start", "data-end"]] }],
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "data-start, data-end",
+            separator: "type",
+          },
+        },
+      ],
+      output: '<input data-start="1" data-end="10" type="text">',
+    },
+    
+    // Partial groups - only some attributes from a group, but they should still be together
+    {
+      code: '<div left="10" class="box" top="20">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "left, top",
+            separator: "class",
+          },
+        },
+      ],
+      output: '<div left="10" top="20" class="box">',
+    },
+    
+    // Partial groups with 3 out of 4 attributes present
+    {
+      code: '<div left="0" width="100" top="10" height="50" right="100">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "width, height",
+            separator: "top",
+          },
+        },
+      ],
+      output: '<div left="0" width="100" height="50" top="10" right="100">',
+    },
+    
+    // Multiple violations - only first one will be reported/fixed
+    {
+      code: '<input min="5" type="text" max="10" width="100" class="test" height="200">',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "min, max",
+            separator: "type",
+          },
+        },
+      ],
+      output: '<input min="5" max="10" type="text" width="100" class="test" height="200">',
+    },
+  ],
+});
+
+templateRuleTester.run("[template] group-attrs", rule, {
+  valid: [
+    {
+      code: 'html`<input min="\\${min}" max="\\${max}">`',
+    },
+    {
+      code: 'html`<div width="100" height="200">`',
+    },
+  ],
+  invalid: [
+    {
+      code: 'html`<input min="\\${min}" type="text" max="\\${max}">`',
+      errors: [
+        {
+          messageId: "notGrouped",
+          data: {
+            attrs: "min, max",
+            separator: "type",
+          },
+        },
+      ],
+      output: 'html`<input min="\\${min}" max="\\${max}" type="text">`',
+    },
+  ],
+});


### PR DESCRIPTION
## Description

Creates a rule for grouping related attributes together. Essentially a more relaxed version of `@html-eslint/sort-attrs`, that gives more flexibility for semantic grouping.