### PR TITLE
Add comparison table with eslint-plugin-jsx-a11y

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,7 @@
   - [Using ESlint Language](#using-eslint-language)
 - [Lint HTML in JavaScript Template Literal](#lint-html-in-javascript-template-literals)
 - [Editor Configuration](#editor-configuration)
+- [Comparison with eslint-plugin-jsx-a11y](#accessibility-comparison-with-eslint-plugin-jsx-a11y)
 
 ## Prerequisites
 
@@ -255,3 +256,65 @@ To enable [vscode-eslint](https://github.com/microsoft/vscode-eslint) support, a
   ]
 }
 ```
+
+## Accessibility comparison with `eslint-plugin-jsx-a11y`
+
+If you're using this plugin along with [eslint-plugin-jsx-a11y](https://www.npmjs.com/package/eslint-plugin-jsx-a11y), here's a mapping of equivalent rules:
+
+<!-- For some reason, it trims the .md extension from external links, so we will add it twice. -->
+| Old Name | New Name | Old Status | New Status |
+|----------|----------|------------|------------|
+| [`accessible-emoji`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/accessible-emoji.md.md) |  | ⚠️ | ❌ |
+| [`alt-text`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/alt-text.md.md) | [`require-img-alt`](rules/require-img-alt.md) | ⭐ | ⭐ |
+| [`anchor-ambiguous-text`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-ambiguous-text.md.md) |  | ⭐ | ❌ |
+| [`anchor-has-content`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-has-content.md.md) |  | ⭐ | ❌ |
+| [`anchor-is-valid`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-is-valid.md.md) |  | ⭐ | ❌ |
+| [`aria-activedescendant-has-tabindex`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-activedescendant-has-tabindex.md.md) |  | ⭐ | ❌ |
+| [`aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-props.md.md) | [`no-invalid-role`](rules/no-invalid-role.md) | ⭐ | ⭐ |
+| [`aria-proptypes`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-proptypes.md.md) | [`no-invalid-role`](rules/no-invalid-role.md) | ⭐ | ⭐ |
+| [`aria-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-role.md.md) | [`no-abstract-roles`](rules/no-abstract-roles.md) | ⭐ | ⭐ |
+| [`aria-unsupported-elements`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-unsupported-elements.md.md) | [`no-invalid-role`](rules/no-invalid-role.md) | ⭐ | ⭐ |
+| [`autocomplete-valid`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/autocomplete-valid.md.md) |  | ⭐ | ❌ |
+| [`click-events-have-key-events`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/click-events-have-key-events.md.md) |  | ⭐ | ❌ |
+| [`control-has-associated-label`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/control-has-associated-label.md.md) | [`require-input-label`](rules/require-input-label.md) | ⭐ | ⭐ |
+| [`heading-has-content`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/heading-has-content.md.md) | [`no-empty-headings`](rules/no-empty-headings.md) | ⭐ | ⭐ |
+| [`html-has-lang`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/html-has-lang.md.md) | [`require-lang`](rules/require-lang.md) | ⭐ | ⭐ |
+| [`iframe-has-title`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/iframe-has-title.md.md) | [`require-frame-title`](rules/require-frame-title.md) | ⭐ | ⭐ |
+| [`img-redundant-alt`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/img-redundant-alt.md.md) |  | ⭐ | ❌ |
+| [`interactive-supports-focus`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/interactive-supports-focus.md.md) |  | ⭐ | ❌ |
+| [`label-has-associated-control`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/label-has-associated-control.md.md) | [`require-input-label`](rules/require-input-label.md) | ⭐ | ⭐ |
+| [`label-has-for`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/label-has-for.md.md) | [`require-input-label`](rules/require-input-label.md) | ⚠️ | ⭐ |
+| [`lang`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/lang.md.md) | [`require-lang`](rules/require-lang.md) | ⭐ | ⭐ |
+| [`media-has-caption`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/media-has-caption.md.md) |  | ⭐ | ❌ |
+| [`mouse-events-have-key-events`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/mouse-events-have-key-events.md.md) |  | ⭐ | ❌ |
+| [`no-access-key`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-access-key.md.md) | [`no-accesskey-attrs`](rules/no-accesskey-attrs.md) | ⭐ | ⭐ |
+| [`no-aria-hidden-on-focusable`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-aria-hidden-on-focusable.md.md) | [`no-aria-hidden-on-focusable`](rules/no-aria-hidden-on-focusable.md) | ⭐ | ⭐ |
+| [`no-autofocus`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-autofocus.md.md) |  | ⭐ | ❌ |
+| [`no-distracting-elements`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-distracting-elements.md.md) |  | ⭐ | ❌ |
+| [`no-interactive-element-to-noninteractive-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-interactive-element-to-noninteractive-role.md) |  | ⭐ | ❌ |
+| [`no-noninteractive-element-interactions`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-interactions.md.md) | [`no-nested-interactive`](rules/no-nested-interactive.md) | ⭐ | ⭐ |
+| [`no-noninteractive-element-to-interactive-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-to-interactive-role.md.md) |  | ⭐ | ❌ |
+| [`no-noninteractive-tabindex`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md.md) | [`no-positive-tabindex`](rules/no-positive-tabindex.md) | ⭐ | ⭐ |
+| [`no-onchange`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-onchange.md.md) |  | ⚠️ | ❌ |
+| [`no-redundant-roles`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md.md) |  | ⭐ | ❌ |
+| [`no-static-element-interactions`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md.md) | [`no-nested-interactive`](rules/no-nested-interactive.md) | ⭐ | ⭐ |
+| [`prefer-tag-over-role`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/prefer-tag-over-role.md.md) |  | ⭐ | ❌ |
+| [`role-has-required-aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/role-has-required-aria-props.md.md) |  | ⭐ | ❌ |
+| [`role-supports-aria-props`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/role-supports-aria-props.md.md) |  | ⭐ | ❌ |
+| [`scope`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/scope.md.md) |  | ⭐ | ❌ |
+| [`tabindex-no-positive`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/tabindex-no-positive.md.md) | [`no-positive-tabindex`](rules/no-positive-tabindex.md) | ⭐ | ⭐ |
+
+### Status Legend
+
+- 🔧 **Fully supported** - Rule is supported, and has an auto-fix
+- ⭐ **Supported** - Rule is supported but doesn't have an auto-fix  
+- 🟡 **Partial support** - Similar but not identical functionality
+- ❌ **Not supported** - No equivalent rule
+- ⚠️ **Warning** - Rule is deprecated in eslint-plugin-jsx-a11y
+
+### Notes
+
+- Many jsx-a11y rules are specific to React/JSX and don't have direct HTML equivalents
+- Some accessibility rules in this plugin are more comprehensive than their jsx-a11y counterparts
+- Rules marked as "Partial support" may cover similar concepts but with different implementation approaches
+- For React/JSX specific accessibility rules, you may still need to use eslint-plugin-jsx-a11y alongside this plugin

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -308,13 +308,5 @@ If you're using this plugin along with [eslint-plugin-jsx-a11y](https://www.npmj
 
 - 🔧 **Fully supported** - Rule is supported, and has an auto-fix
 - ⭐ **Supported** - Rule is supported but doesn't have an auto-fix  
-- 🟡 **Partial support** - Similar but not identical functionality
 - ❌ **Not supported** - No equivalent rule
 - ⚠️ **Warning** - Rule is deprecated in eslint-plugin-jsx-a11y
-
-### Notes
-
-- Many jsx-a11y rules are specific to React/JSX and don't have direct HTML equivalents
-- Some accessibility rules in this plugin are more comprehensive than their jsx-a11y counterparts
-- Rules marked as "Partial support" may cover similar concepts but with different implementation approaches
-- For React/JSX specific accessibility rules, you may still need to use eslint-plugin-jsx-a11y alongside this plugin


### PR DESCRIPTION
## Checklist

- Starts work on #385 by identifying conflicting rules (as well as missing generalized accessibility rules)

## Description

This is helpful for identifying accessibility rules that this plugin currently doesn't implement, so that I can correctly enable both plugins at the same time.