### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/packages/eslint-plugin/lib/rules/attrs-newline.js
+++ b/packages/eslint-plugin/lib/rules/attrs-newline.js
@@ -48,6 +48,7 @@ module.exports = {
             type: "integer",
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/packages/eslint-plugin/lib/rules/element-newline.js
+++ b/packages/eslint-plugin/lib/rules/element-newline.js
@@ -97,6 +97,7 @@ module.exports = {
             },
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -97,6 +97,7 @@ module.exports = {
             additionalProperties: false,
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-attrs.js
@@ -60,6 +60,7 @@ module.exports = {
             type: "boolean",
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/packages/eslint-plugin/lib/rules/no-restricted-attr-values.js
+++ b/packages/eslint-plugin/lib/rules/no-restricted-attr-values.js
@@ -50,6 +50,7 @@ module.exports = {
             type: "string",
           },
         },
+        additionalProperties: false,
       },
     },
     messages: {

--- a/packages/eslint-plugin/lib/rules/no-restricted-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-restricted-attrs.js
@@ -52,6 +52,7 @@ module.exports = {
             type: "string",
           },
         },
+        additionalProperties: false,
       },
     },
     messages: {

--- a/packages/eslint-plugin/lib/rules/require-img-alt.js
+++ b/packages/eslint-plugin/lib/rules/require-img-alt.js
@@ -42,6 +42,7 @@ module.exports = {
             },
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {

--- a/packages/eslint-plugin/lib/rules/sort-attrs.js
+++ b/packages/eslint-plugin/lib/rules/sort-attrs.js
@@ -42,6 +42,7 @@ module.exports = {
             },
           },
         },
+        additionalProperties: false,
       },
     ],
     messages: {


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: fixes https://github.com/yeonjuan/html-eslint/issues/388

## Description

This PR simply disallows extra properties in rules' schemas which currently allow them.