### PR TITLE
refactor: add cache for template literal parsing

### DIFF
--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -20,7 +20,8 @@
  * @property {Record<string, number>} [Option2.tagChildrenIndent]
  */
 
-const { parse } = require("@html-eslint/template-parser");
+const { getCachedParseResult } = require("../utils/template-cache");
+const { traverse } = require("@html-eslint/template-parser/lib/traverser");
 const { NODE_TYPES } = require("@html-eslint/parser");
 const { RULE_CATEGORY } = require("../../constants");
 const {
@@ -386,13 +387,18 @@ module.exports = {
       TaggedTemplateExpression(node) {
         if (shouldCheckTaggedTemplateExpression(node, context)) {
           const base = getTemplateLiteralBaseIndentLevel(node.quasi);
-          parse(node.quasi, getSourceCode(context), createIndentVisitor(base));
+          const { ast } = getCachedParseResult(
+            node.quasi,
+            getSourceCode(context)
+          );
+          traverse(ast, createIndentVisitor(base), null);
         }
       },
       TemplateLiteral(node) {
         if (shouldCheckTemplateLiteral(node, context)) {
           const base = getTemplateLiteralBaseIndentLevel(node);
-          parse(node, getSourceCode(context), createIndentVisitor(base));
+          const { ast } = getCachedParseResult(node, getSourceCode(context));
+          traverse(ast, createIndentVisitor(base), null);
         }
       },
     };

--- a/packages/eslint-plugin/lib/rules/no-duplicate-id.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-id.js
@@ -3,7 +3,8 @@
  * @import {RuleModule} from "../types";
  */
 
-const { parse } = require("@html-eslint/template-parser");
+const { getCachedParseResult } = require("./utils/template-cache");
+const { traverse } = require("@html-eslint/template-parser/lib/traverser");
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
 const {
@@ -90,18 +91,31 @@ module.exports = {
       TaggedTemplateExpression(node) {
         const idAttrsMap = new Map();
         if (shouldCheckTaggedTemplateExpression(node, context)) {
-          parse(node.quasi, getSourceCode(context), {
-            Tag: createTagVisitor(idAttrsMap),
-          });
+          const { ast } = getCachedParseResult(
+            node.quasi,
+            getSourceCode(context)
+          );
+          traverse(
+            ast,
+            {
+              Tag: createTagVisitor(idAttrsMap),
+            },
+            null
+          );
         }
         report(idAttrsMap);
       },
       TemplateLiteral(node) {
         const idAttrsMap = new Map();
         if (shouldCheckTemplateLiteral(node, context)) {
-          parse(node, getSourceCode(context), {
-            Tag: createTagVisitor(idAttrsMap),
-          });
+          const { ast } = getCachedParseResult(node, getSourceCode(context));
+          traverse(
+            ast,
+            {
+              Tag: createTagVisitor(idAttrsMap),
+            },
+            null
+          );
         }
         report(idAttrsMap);
       },

--- a/packages/eslint-plugin/lib/rules/no-duplicate-in-head.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-in-head.js
@@ -3,7 +3,8 @@
  * @import {RuleModule} from "../types";
  */
 
-const { parse } = require("@html-eslint/template-parser");
+const { getCachedParseResult } = require("./utils/template-cache");
+const { traverse } = require("@html-eslint/template-parser/lib/traverser");
 const { RULE_CATEGORY } = require("../constants");
 const { findAttr } = require("./utils/node");
 const {
@@ -168,7 +169,11 @@ module.exports = {
 
         if (shouldCheckTaggedTemplateExpression(node, context)) {
           const visitor = createTagVisitor(tagsMap, headCountRef);
-          parse(node.quasi, getSourceCode(context), visitor);
+          const { ast } = getCachedParseResult(
+            node.quasi,
+            getSourceCode(context)
+          );
+          traverse(ast, visitor, null);
           report(tagsMap);
         }
       },
@@ -179,7 +184,8 @@ module.exports = {
 
         if (shouldCheckTemplateLiteral(node, context)) {
           const visitor = createTagVisitor(tagsMap, headCountRef);
-          parse(node, getSourceCode(context), visitor);
+          const { ast } = getCachedParseResult(node, getSourceCode(context));
+          traverse(ast, visitor, null);
           report(tagsMap);
         }
       },

--- a/packages/eslint-plugin/lib/rules/no-multiple-empty-lines.js
+++ b/packages/eslint-plugin/lib/rules/no-multiple-empty-lines.js
@@ -6,7 +6,7 @@
  * @property {number} Option.max
  */
 
-const { parse } = require("@html-eslint/template-parser");
+const { getCachedParseResult } = require("./utils/template-cache");
 const { RULE_CATEGORY } = require("../constants");
 const {
   shouldCheckTaggedTemplateExpression,
@@ -117,10 +117,9 @@ module.exports = {
       },
       TaggedTemplateExpression(node) {
         if (shouldCheckTaggedTemplateExpression(node, context)) {
-          const { html, tokens } = parse(
+          const { html, tokens } = getCachedParseResult(
             node.quasi,
-            getSourceCode(context),
-            {}
+            getSourceCode(context)
           );
           const lines = codeToLines(html);
           check(
@@ -133,7 +132,10 @@ module.exports = {
       },
       TemplateLiteral(node) {
         if (shouldCheckTemplateLiteral(node, context)) {
-          const { html, tokens } = parse(node, getSourceCode(context), {});
+          const { html, tokens } = getCachedParseResult(
+            node,
+            getSourceCode(context)
+          );
           const lines = codeToLines(html);
           check(
             lines,

--- a/packages/eslint-plugin/lib/rules/no-trailing-spaces.js
+++ b/packages/eslint-plugin/lib/rules/no-trailing-spaces.js
@@ -3,7 +3,7 @@
  * @import {CommentContent, Text} from "@html-eslint/types";
  */
 
-const { parse } = require("@html-eslint/template-parser");
+const { getCachedParseResult } = require("./utils/template-cache");
 const { RULE_CATEGORY } = require("../constants");
 const {
   getTemplateTokens,
@@ -107,10 +107,9 @@ module.exports = {
       },
       TaggedTemplateExpression(node) {
         if (shouldCheckTaggedTemplateExpression(node, context)) {
-          const { html, tokens } = parse(
+          const { html, tokens } = getCachedParseResult(
             node.quasi,
-            getSourceCode(context),
-            {}
+            getSourceCode(context)
           );
           const lines = codeToLines(html);
           check(
@@ -127,7 +126,10 @@ module.exports = {
       },
       TemplateLiteral(node) {
         if (shouldCheckTemplateLiteral(node, context)) {
-          const { html, tokens } = parse(node, getSourceCode(context), {});
+          const { html, tokens } = getCachedParseResult(
+            node,
+            getSourceCode(context)
+          );
           const lines = codeToLines(html);
           check(
             html,

--- a/packages/eslint-plugin/lib/rules/utils/template-cache.js
+++ b/packages/eslint-plugin/lib/rules/utils/template-cache.js
@@ -1,0 +1,36 @@
+/**
+ * @import {TemplateLiteral} from "@html-eslint/types";
+ * @import {DocumentNode, AnyToken} from "es-html-parser";
+ * @import {SourceCode} from "eslint";
+ */
+
+const { parse } = require("@html-eslint/template-parser");
+
+/**
+ * Cache for parsed template literals to avoid re-parsing the same template multiple times.
+ * Uses WeakMap for automatic garbage collection when nodes are no longer referenced.
+ * @type {WeakMap<TemplateLiteral, {ast: any, html: string, tokens: any[]}>}
+ */
+const templateCache = new WeakMap();
+
+/**
+ * Get or create cached parse result for a template literal.
+ * @param {TemplateLiteral} node
+ * @param {SourceCode} sourceCode
+ * @returns {{ast: DocumentNode, html: string, tokens: AnyToken[]}}
+ */
+function getCachedParseResult(node, sourceCode) {
+  // Check if we already have a cached result for this node
+  const cachedResult = templateCache.get(node);
+  if (cachedResult) {
+    return cachedResult;
+  }
+
+  // Parse and cache the result
+  const result = parse(node, sourceCode, {});
+  templateCache.set(node, result);
+
+  return result;
+}
+
+module.exports = { getCachedParseResult };

--- a/packages/eslint-plugin/lib/rules/utils/visitors.js
+++ b/packages/eslint-plugin/lib/rules/utils/visitors.js
@@ -6,7 +6,8 @@ const {
   shouldCheckTaggedTemplateExpression,
   shouldCheckTemplateLiteral,
 } = require("./settings");
-const { parse } = require("@html-eslint/template-parser");
+const { getCachedParseResult } = require("./template-cache");
+const { traverse } = require("@html-eslint/template-parser/lib/traverser");
 const { getSourceCode } = require("./source-code");
 
 /**
@@ -18,12 +19,17 @@ function createTemplateVisitors(context, visitors) {
   return {
     TaggedTemplateExpression(node) {
       if (shouldCheckTaggedTemplateExpression(node, context)) {
-        parse(node.quasi, getSourceCode(context), visitors);
+        const { ast } = getCachedParseResult(
+          node.quasi,
+          getSourceCode(context)
+        );
+        traverse(ast, visitors, null);
       }
     },
     TemplateLiteral(node) {
       if (shouldCheckTemplateLiteral(node, context)) {
-        parse(node, getSourceCode(context), visitors);
+        const { ast } = getCachedParseResult(node, getSourceCode(context));
+        traverse(ast, visitors, null);
       }
     },
   };


### PR DESCRIPTION
Adding per-node caching of parse results gives a **94% performance improvement** in my project. Before, the rules collectively took ~21s. Now, they take just ~1.2s.

Before:

```
TIMING=all yarn eslint --stats "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}" | grep "@html-eslint/"
@html-eslint/no-positive-tabindex                                         |   723.208 |     3.0%
@html-eslint/require-lang                                                 |   721.106 |     3.0%
@html-eslint/no-empty-headings                                            |   718.906 |     3.0%
@html-eslint/no-extra-spacing-attrs                                       |   714.442 |     3.0%
@html-eslint/quotes                                                       |   714.293 |     3.0%
@html-eslint/no-script-style-type                                         |   714.260 |     3.0%
@html-eslint/lowercase                                                    |   713.597 |     3.0%
@html-eslint/no-duplicate-class                                           |   712.460 |     3.0%
@html-eslint/no-restricted-attrs                                          |   712.457 |     3.0%
@html-eslint/max-element-depth                                            |   712.232 |     3.0%
@html-eslint/no-accesskey-attrs                                           |   711.985 |     3.0%
@html-eslint/no-multiple-empty-lines                                      |   710.888 |     3.0%
@html-eslint/no-extra-spacing-text                                        |   709.951 |     3.0%
@html-eslint/no-invalid-role                                              |   709.517 |     3.0%
@html-eslint/no-duplicate-id                                              |   708.535 |     3.0%
@html-eslint/no-duplicate-attrs                                           |   707.221 |     2.9%
@html-eslint/no-aria-hidden-on-focusable                                  |   707.086 |     2.9%
@html-eslint/prefer-https                                                 |   706.865 |     2.9%
@html-eslint/require-frame-title                                          |   706.811 |     2.9%
@html-eslint/no-invalid-entity                                            |   706.053 |     2.9%
@html-eslint/no-nested-interactive                                        |   705.981 |     2.9%
@html-eslint/no-obsolete-tags                                             |   705.818 |     2.9%
@html-eslint/require-closing-tags                                         |   705.428 |     2.9%
@html-eslint/no-duplicate-in-head                                         |   704.789 |     2.9%
@html-eslint/require-attrs                                                |   704.250 |     2.9%
@html-eslint/no-abstract-roles                                            |   703.733 |     2.9%
@html-eslint/require-img-alt                                              |   703.546 |     2.9%
@html-eslint/no-restricted-attr-values                                    |   703.156 |     2.9%
@html-eslint/no-target-blank                                              |   701.685 |     2.9%
@html-eslint/no-aria-hidden-body                                          |   699.780 |     2.9%
@html-eslint/require-open-graph-protocol                                  |     0.863 |     0.0%
@html-eslint/require-doctype                                              |     0.215 |     0.0%
@html-eslint/no-multiple-h1                                               |     0.214 |     0.0%
@html-eslint/no-skip-heading-levels                                       |     0.194 |     0.0%
@html-eslint/require-meta-description                                     |     0.174 |     0.0%
@html-eslint/require-meta-charset                                         |     0.163 |     0.0%
@html-eslint/require-li-container                                         |     0.154 |     0.0%
@html-eslint/require-title                                                |     0.151 |     0.0%
@html-eslint/require-meta-viewport                                        |     0.146 |     0.0%
@html-eslint/no-non-scalable-viewport                                     |     0.142 |     0.0%
```

After:

```
TIMING=all yarn eslint --stats "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}" | grep "@html-eslint/"
@html-eslint/require-lang                                                 |   884.916 |    21.8%
@html-eslint/lowercase                                                    |    21.117 |     0.5%
@html-eslint/no-extra-spacing-text                                        |    15.848 |     0.4%
@html-eslint/no-duplicate-attrs                                           |    15.593 |     0.4%
@html-eslint/require-closing-tags                                         |    15.490 |     0.4%
@html-eslint/no-restricted-attr-values                                    |    14.099 |     0.3%
@html-eslint/no-extra-spacing-attrs                                       |    14.003 |     0.3%
@html-eslint/quotes                                                       |    13.205 |     0.3%
@html-eslint/no-duplicate-class                                           |    13.096 |     0.3%
@html-eslint/no-duplicate-id                                              |    12.442 |     0.3%
@html-eslint/no-duplicate-in-head                                         |    12.129 |     0.3%
@html-eslint/no-invalid-entity                                            |    11.666 |     0.3%
@html-eslint/no-nested-interactive                                        |    11.341 |     0.3%
@html-eslint/max-element-depth                                            |    11.340 |     0.3%
@html-eslint/no-empty-headings                                            |    10.995 |     0.3%
@html-eslint/no-positive-tabindex                                         |    10.920 |     0.3%
@html-eslint/prefer-https                                                 |    10.885 |     0.3%
@html-eslint/require-attrs                                                |    10.769 |     0.3%
@html-eslint/no-restricted-attrs                                          |    10.661 |     0.3%
@html-eslint/require-img-alt                                              |    10.593 |     0.3%
@html-eslint/no-accesskey-attrs                                           |    10.588 |     0.3%
@html-eslint/no-invalid-role                                              |    10.546 |     0.3%
@html-eslint/no-obsolete-tags                                             |    10.417 |     0.3%
@html-eslint/no-abstract-roles                                            |    10.298 |     0.3%
@html-eslint/no-aria-hidden-on-focusable                                  |    10.287 |     0.3%
@html-eslint/no-script-style-type                                         |    10.271 |     0.3%
@html-eslint/no-target-blank                                              |    10.183 |     0.3%
@html-eslint/require-frame-title                                          |    10.109 |     0.2%
@html-eslint/no-aria-hidden-body                                          |     9.953 |     0.2%
@html-eslint/no-multiple-empty-lines                                      |     8.756 |     0.2%
@html-eslint/require-open-graph-protocol                                  |     0.821 |     0.0%
@html-eslint/no-multiple-h1                                               |     0.219 |     0.0%
@html-eslint/no-skip-heading-levels                                       |     0.215 |     0.0%
@html-eslint/require-doctype                                              |     0.194 |     0.0%
@html-eslint/require-title                                                |     0.177 |     0.0%
@html-eslint/require-li-container                                         |     0.173 |     0.0%
@html-eslint/require-meta-description                                     |     0.172 |     0.0%
@html-eslint/require-meta-viewport                                        |     0.162 |     0.0%
@html-eslint/no-non-scalable-viewport                                     |     0.156 |     0.0%
@html-eslint/require-meta-charset                                         |     0.138 |     0.0%
```

This code was developed with the help of Claude Sonnet 4.