### PR TITLE
docs(rule: quote): disclaimer enforceTemplatedAttrValue implicitly bans bare templated attributes, clarify object option

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -16,14 +16,14 @@ module.exports = {
 
 ### Options
 
-This rule accepts the following options
+This rule has two options, a string option and an object option.
 
-1. Quote style (string):
-   - "double" (default): Enforces the use of double quotes (`"`).
-   - "single": Enforces the use of single quotes (`'`).
-2. `enforceTemplatedAttrValue` (boolean):
-   - false (default): Does not enforce quote style inside template expressions.
-   - true: Enforces quote style inside templated attribute values.
+1. String option (quote style):
+   - `"double"` (default) enforces the use of double quotes (`"`)
+   - `"single"` enforces the use of single quotes (`'`)
+2. Object option:
+   - `"enforceTemplatedAttrValue": false` (default) does not enforce quote style inside template expressions
+   - `"enforceTemplatedAttrValue": true` enforces quote style inside templated attribute values, which also means bare templated attributes are disallowed
 
 #### "double"
 


### PR DESCRIPTION
- also, align option notation style to ESLint

## Checklist

- Addresses an existing open issue: fixes #394

## Description
