### PR TITLE
fix: tagChildrenIndent Not applied to text child

### DIFF
--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -1,5 +1,5 @@
 /**
- * @import {AnyNode, Tag, TemplateText, TemplateLiteral, OpenTemplate, CloseTemplate, ScriptTag, StyleTag} from "@html-eslint/types";
+ * @import {AnyNode, Tag, TemplateText, TemplateLiteral, OpenTemplate, CloseTemplate, ScriptTag, StyleTag, Text} from "@html-eslint/types";
  * @import {Line, RuleListener, Context, RuleModule} from "../../types";
  * @import {AST} from "eslint";
  *
@@ -30,6 +30,7 @@ const {
   hasTemplate,
   isScript,
   isStyle,
+  isText,
 } = require("../utils/node");
 const {
   shouldCheckTaggedTemplateExpression,
@@ -112,7 +113,7 @@ module.exports = {
     const { indentType, indentSize, indentChar } = getIndentOptionInfo(context);
 
     /**
-     * @param {Tag | ScriptTag | StyleTag} node
+     * @param {Tag | ScriptTag | StyleTag | Text} node
      * @return {number}
      */
     function getTagIncreasingLevel(node) {
@@ -141,7 +142,7 @@ module.exports = {
       if (isLine(node)) {
         return 1;
       }
-      if (isTag(node) || isScript(node) || isStyle(node)) {
+      if (isTag(node) || isScript(node) || isStyle(node) || isText(node)) {
         return getTagIncreasingLevel(node);
       }
       const type = node.type;

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -489,6 +489,36 @@ class Example {
           },
         },
       },
+      {
+        code: `
+<div>
+text
+</div>
+        `,
+        options: [
+          2,
+          {
+            tagChildrenIndent: {
+              div: 0,
+            },
+          },
+        ],
+      },
+      {
+        code: `
+<div>
+        text
+</div>
+        `,
+        options: [
+          2,
+          {
+            tagChildrenIndent: {
+              div: 4,
+            },
+          },
+        ],
+      },
     ],
     invalid: [
       {
@@ -1170,6 +1200,27 @@ id="bar"
       },
       {
         code: `
+<div>
+  text
+</div>
+        `,
+        output: `
+<div>
+text
+</div>
+        `,
+        errors: wrongIndentErrors(1),
+        options: [
+          2,
+          {
+            tagChildrenIndent: {
+              div: 0,
+            },
+          },
+        ],
+      },
+      {
+        code: `
 <style>
    </style>
 <script>
@@ -1433,6 +1484,23 @@ const code = html\`
         {
           tagChildrenIndent: {
             html: 0,
+          },
+        },
+      ],
+    },
+    {
+      code: `html\`
+  <span>
+    <div>
+    text
+    </div>
+  </span>
+      \``,
+      options: [
+        2,
+        {
+          tagChildrenIndent: {
+            div: 0,
           },
         },
       ],


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: fixes #406

## Description
