### PR TITLE
feat: support linting doctype in lowercase

### DIFF
--- a/packages/eslint-plugin/lib/rules/lowercase.js
+++ b/packages/eslint-plugin/lib/rules/lowercase.js
@@ -1,5 +1,10 @@
 /**
- * @import {Tag, StyleTag, ScriptTag} from "@html-eslint/types";
+ * @import {
+ *   Tag,
+ *   StyleTag,
+ *   ScriptTag,
+ *   Doctype,
+ * } from "@html-eslint/types";
  * @import {RuleModule} from "../types";
  */
 
@@ -128,6 +133,48 @@ module.exports = {
       }
     }
 
+    /**
+     * @param {Doctype} doctype
+     */
+    function checkDoctype(doctype) {
+      if (doctype.open.value !== doctype.open.value.toLowerCase()) {
+        context.report({
+          node: doctype.open,
+          messageId: MESSAGE_IDS.UNEXPECTED,
+          data: {
+            name: doctype.open.value.slice(1),
+          },
+          fix(fixer) {
+            return fixer.replaceTextRange(doctype.open.range, "<!doctype");
+          },
+        });
+      }
+      if (doctype.attributes && doctype.attributes.length) {
+        doctype.attributes.forEach((attribute) => {
+          if (
+            attribute.value &&
+            attribute.value.value !== attribute.value.value.toLowerCase()
+          ) {
+            context.report({
+              node: attribute.value,
+              messageId: MESSAGE_IDS.UNEXPECTED,
+              data: {
+                name: attribute.value.value,
+              },
+              fix(fixer) {
+                return fixer.replaceText(
+                  // @ts-ignore
+                  attribute.value,
+                  // @ts-ignore
+                  attribute.value.value.toLowerCase()
+                );
+              },
+            });
+          }
+        });
+      }
+    }
+
     return createVisitors(context, {
       Tag(node) {
         if (node.name.toLocaleLowerCase() === "svg") {
@@ -142,6 +189,7 @@ module.exports = {
       },
       StyleTag: check,
       ScriptTag: check,
+      Doctype: checkDoctype,
     });
   },
 };

--- a/packages/eslint-plugin/tests/rules/lowercase.test.js
+++ b/packages/eslint-plugin/tests/rules/lowercase.test.js
@@ -53,6 +53,9 @@ ruleTester.run("lowercase", rule, {
 `,
     },
     {
+      code: `<!doctype html>`,
+    },
+    {
       code: "<div {{ID}}></div>",
       languageOptions: {
         parserOptions: {
@@ -124,6 +127,24 @@ ruleTester.run("lowercase", rule, {
       errors: [
         {
           message: "'SVG' is not in lowercase.",
+        },
+      ],
+    },
+    {
+      code: `<!DOCTYPE html>`,
+      output: `<!doctype html>`,
+      errors: [
+        {
+          message: "'!DOCTYPE' is not in lowercase.",
+        },
+      ],
+    },
+    {
+      code: `<!doctype HTML>`,
+      output: `<!doctype html>`,
+      errors: [
+        {
+          message: "'HTML' is not in lowercase.",
         },
       ],
     },

--- a/packages/website/src/scripts/playground/helpers.js
+++ b/packages/website/src/scripts/playground/helpers.js
@@ -44,7 +44,7 @@ export function escapeHTML(str) {
     .replace(/>/g, "&gt;");
 }
 
-export const INITIAL_HTML = html`<!DOCTYPE html>
+export const INITIAL_HTML = html`<!doctype html>
   <html>
     <head>
     </head>


### PR DESCRIPTION
## Checklist

- Fixes #410

## Description

This commit adds detection and fixers of not-lowercase doctypes in documents, eg. `<!DOCTYPE html>`, `<!doctype HTML>`, or any other capitalization besides the all-lowercased `<!doctype html>`.

I originally wanted to condense the changes to the rule in a single generalized `check()` function, but that ended up feeling kludgy because of the different shape of `Doctype` versus the existing assumptions for the input `Tag | StyleTag | ScriptTag` types. As a result, there is some duplicated code in my implementation here--I'd be happy to clean that up if there is a more ideal structure you'd like to see.