### PR TITLE
Mention priority ordering in `sort-attrs` documentation

### DIFF
--- a/docs/rules/sort-attrs.md
+++ b/docs/rules/sort-attrs.md
@@ -1,6 +1,6 @@
 # sort-attrs
 
-This rule enforces alphabetical sorting of attributes.
+This rule enforces priority-based and alphabetical sorting of attributes.
 
 ## How to use
 

--- a/packages/eslint-plugin/lib/rules/sort-attrs.js
+++ b/packages/eslint-plugin/lib/rules/sort-attrs.js
@@ -24,7 +24,7 @@ module.exports = {
     type: "code",
 
     docs: {
-      description: "Enforce attributes alphabetical sorting",
+      description: "Enforce priority and alphabetical sorting of attributes",
       category: RULE_CATEGORY.STYLE,
       recommended: false,
       url: getRuleUrl("sort-attrs"),
@@ -60,7 +60,7 @@ module.exports = {
       },
     ],
     messages: {
-      [MESSAGE_IDS.UNSORTED]: "Attributes should be sorted alphabetically",
+      [MESSAGE_IDS.UNSORTED]: "Attributes should be sorted by priority and alphabetically",
     },
   },
   create(context) {


### PR DESCRIPTION
A coworker expressed confusion about why `type` would be sorted before `class` when the rule's error message says "Attributes should be sorted alphabetically." Updating the rule's error message and documentation to mention the priority sorting behavior should avoid future confusion.