### PR TITLE
fix: allow img alt in no-empty-headings

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-empty-headings.js
+++ b/packages/eslint-plugin/lib/rules/no-empty-headings.js
@@ -37,17 +37,32 @@ function isRoleHeading(node) {
 }
 
 /**
+ * @param {Tag} node
+ * @returns {string}
+ */
+function getAltText(node) {
+  if (node.name.toLowerCase() === "img") {
+    const altAttr = findAttr(node, "alt");
+    if (altAttr && altAttr.value && altAttr.value.value) {
+      return altAttr.value.value;
+    }
+  }
+  return "";
+}
+
+/**
  * @param {Text | Tag} node
  * @returns {string}
  */
 function getAllText(node) {
-  if (!isTag(node) || !node.children.length) return "";
+  if (!isTag(node)) return "";
+
   let text = "";
   for (const child of node.children) {
     if (isText(child)) {
       text += child.value.trim();
     } else if (isTag(child)) {
-      text += getAllText(child);
+      text += getAllText(child) || getAltText(child);
     }
   }
   return text;
@@ -64,7 +79,7 @@ function getAccessibleText(node) {
     if (isText(child)) {
       text += child.value.trim();
     } else if (isTag(child) && !isAriaHidden(child)) {
-      text += getAccessibleText(child);
+      text += getAccessibleText(child) || getAltText(child);
     }
   }
   return text;

--- a/packages/eslint-plugin/tests/rules/no-empty-headings.test.js
+++ b/packages/eslint-plugin/tests/rules/no-empty-headings.test.js
@@ -15,6 +15,9 @@ ruleTester.run("no-empty-headings", rule, {
     {
       code: '<h2><span aria-hidden="true">Hidden</span><span>Visible</span></h2>',
     },
+    {
+      code: `<h1><img src="./img.svg" alt="Images description" /></h1>`,
+    },
   ],
   invalid: [
     {
@@ -48,6 +51,10 @@ ruleTester.run("no-empty-headings", rule, {
     {
       code: `<h4>
 </h4>`,
+      errors: [{ messageId: "emptyHeading" }],
+    },
+    {
+      code: `<h4><img src="./image.svg" /></h4>`,
       errors: [{ messageId: "emptyHeading" }],
     },
   ],


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: fixes #452 

## Description
