### PR TITLE
feat: add autofix to require-meta-charset rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -36,7 +36,7 @@
 | [require-doctype](rules/require-doctype)                         | Require `<!DOCTYPE HTML>` in HTML                                                              | ⭐ 🔧 |
 | [require-explicit-size](rules/require-explicit-size)             | Enforces that some elements (img, iframe) have explicitly defined width and height attributes. |       |
 | [require-li-container](rules/require-li-container)               | Enforce `<li>` to be in `<ul>`, `<ol>` or `<menu>`.                                            | ⭐    |
-| [require-meta-charset](rules/require-meta-charset)               | Enforce use of `<meta charset="...">` in `<head>`                                              |       |
+| [require-meta-charset](rules/require-meta-charset)               | Enforce use of `<meta charset="...">` in `<head>`                                              | 🔧    |
 | [use-baseline](rules/use-baseline)                               | Enforce the use of baseline features.                                                          | ⭐    |
 
 ## SEO

--- a/packages/eslint-plugin/lib/rules/require-meta-charset.js
+++ b/packages/eslint-plugin/lib/rules/require-meta-charset.js
@@ -36,7 +36,7 @@ module.exports = {
       url: getRuleUrl("require-meta-charset"),
     },
 
-    fixable: null,
+    fixable: "code",
     schema: [],
     messages: {
       [MESSAGE_IDS.MISSING]: 'Missing `<meta charset="...">`.',
@@ -57,6 +57,12 @@ module.exports = {
           context.report({
             node,
             messageId: MESSAGE_IDS.MISSING,
+            fix(fixer) {
+              return fixer.insertTextAfter(
+                node.openEnd,
+                '<meta charset="utf-8">'
+              );
+            },
           });
           return;
         }
@@ -68,6 +74,9 @@ module.exports = {
             context.report({
               node: charsetAttr,
               messageId: MESSAGE_IDS.EMPTY,
+              fix(fixer) {
+                return fixer.replaceText(charsetAttr, 'charset="utf-8"');
+              },
             });
           }
         }

--- a/packages/eslint-plugin/tests/rules/require-meta-charset.test.js
+++ b/packages/eslint-plugin/tests/rules/require-meta-charset.test.js
@@ -32,7 +32,13 @@ ruleTester.run("require-meta-charset", rule, {
       </head>
 </html>
 `,
-
+      output: `
+<html>
+      <head><meta charset="utf-8">
+          <meta name="description">
+      </head>
+</html>
+`,
       errors: [
         {
           messageId: "missing",
@@ -43,6 +49,12 @@ ruleTester.run("require-meta-charset", rule, {
       code: `
 <html>
       <head>
+      </head>
+</html>
+`,
+      output: `
+<html>
+      <head><meta charset="utf-8">
       </head>
 </html>
 `,
@@ -60,6 +72,13 @@ ruleTester.run("require-meta-charset", rule, {
       </head>
 </html>
 `,
+      output: `
+<html>
+      <head>
+          <meta charset="utf-8">
+      </head>
+</html>
+`,
       errors: [
         {
           messageId: "empty",
@@ -70,6 +89,14 @@ ruleTester.run("require-meta-charset", rule, {
       code: `
 <html>
       <head>
+        <title> title </title>
+        <meta foo="charset">
+      </head>
+</html>
+`,
+      output: `
+<html>
+      <head><meta charset="utf-8">
         <title> title </title>
         <meta foo="charset">
       </head>


### PR DESCRIPTION
## Summary

This PR adds autofix support to the `require-meta-charset` rule as requested in #517.

## Changes

### Autofix Behavior

1. **Missing `<meta charset>` tag**: Inserts `<meta charset="utf-8">` as the first element after the opening `<head>` tag.

2. **Empty charset attribute**: Replaces the empty charset attribute with `charset="utf-8"`.

### Implementation Details

- Changed `fixable: null` to `fixable: "code"` in rule meta
- Added `fix` function to both error cases (`MISSING` and `EMPTY`)
- Updated tests to include expected autofix output

## Testing

All existing tests pass. Added autofix output expectations to the test cases.

Closes #517