### PR TITLE
fix(no-redundant-role): restore missing html-standard dependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -45,7 +45,8 @@
     "@html-eslint/template-parser": "^0.57.0",
     "@html-eslint/template-syntax-parser": "^0.57.0",
     "@html-eslint/types": "^0.57.0",
-    "@rviscomi/capo.js": "^2.1.0"
+    "@rviscomi/capo.js": "^2.1.0",
+    "html-standard": "^0.0.13"
   },
   "peerDependencies": {
     "eslint": ">=8.0.0 || ^10.0.0-0"


### PR DESCRIPTION
## Problem

Fixes #526

The `no-redundant-role` rule imports from `html-standard`:

```js
// packages/eslint-plugin/lib/rules/no-redundant-role.js
const { element } = require('html-standard');
```

But `html-standard` was accidentally removed from `dependencies` in 7393881 ("feat: add react/no-obsolete-tags"). This causes the rule to crash at import time with a missing module error.

## Fix

Restore `html-standard` to `dependencies`, bumped to current latest (`^0.0.13`; was `^0.0.11` before removal).

```diff
- "@rviscomi/capo.js": "^2.1.0"
+ "@rviscomi/capo.js": "^2.1.0",
+ "html-standard": "^0.0.13"
```

## Notes

- One-line package.json change — no logic touched
- Confirmed the import is still present and unchanged in `no-redundant-role.js`