### PR TITLE
feat(no-extra-spacing-tags): add rule, deprecate no-extra-spacing-attrs

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -82,6 +82,7 @@
 | [indent](rules/indent)                                   | Enforce consistent indentation                                    | ⭐ 🔧 |
 | [lowercase](rules/lowercase)                             | Enforce use of lowercase for tag and attribute names.             | 🔧    |
 | [no-extra-spacing-attrs](rules/no-extra-spacing-attrs)   | Disallow extra spacing around attributes                          | ⭐ 🔧 |
+| [no-extra-spacing-tags](rules/no-extra-spacing-tags)     | Disallow extra spacing inside tags                                | ⭐ 🔧 |
 | [no-extra-spacing-text](rules/no-extra-spacing-text)     | Disallow unnecessary consecutive spaces                           | 🔧    |
 | [no-multiple-empty-lines](rules/no-multiple-empty-lines) | Disallow multiple empty lines                                     | 🔧    |
 | [no-trailing-spaces](rules/no-trailing-spaces)           | Disallow trailing whitespace at the end of lines                  | 🔧    |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -73,18 +73,18 @@
 
 ## Style
 
-| Rule                                                     | Description                                                       |       |
-| -------------------------------------------------------- | ----------------------------------------------------------------- | ----- |
-| [attrs-newline](rules/attrs-newline)                     | Enforce newline between attributes                                | ⭐ 🔧 |
-| [class-spacing](rules/class-spacing)                     | Disallow extra spacing in class attribute values                  | 🔧    |
-| [element-newline](rules/element-newline)                 | Enforce newline between elements.                                 | ⭐ 🔧 |
-| [id-naming-convention](rules/id-naming-convention)       | Enforce consistent naming of id attributes                        |       |
-| [indent](rules/indent)                                   | Enforce consistent indentation                                    | ⭐ 🔧 |
-| [lowercase](rules/lowercase)                             | Enforce use of lowercase for tag and attribute names.             | 🔧    |
-| [no-extra-spacing-attrs](rules/no-extra-spacing-attrs)   | Disallow extra spacing around attributes                          | ⭐ 🔧 |
-| [no-extra-spacing-tags](rules/no-extra-spacing-tags)     | Disallow extra spacing inside tags                                | ⭐ 🔧 |
-| [no-extra-spacing-text](rules/no-extra-spacing-text)     | Disallow unnecessary consecutive spaces                           | 🔧    |
-| [no-multiple-empty-lines](rules/no-multiple-empty-lines) | Disallow multiple empty lines                                     | 🔧    |
-| [no-trailing-spaces](rules/no-trailing-spaces)           | Disallow trailing whitespace at the end of lines                  | 🔧    |
-| [quotes](rules/quotes)                                   | Enforce consistent quoting attributes with double(") or single(') | ⭐ 🔧 |
-| [sort-attrs](rules/sort-attrs)                           | Enforce priority and alphabetical sorting of attributes           | 🔧    |
+| Rule                                                       | Description                                                                                                                 |       |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----- |
+| [attrs-newline](rules/attrs-newline)                       | Enforce newline between attributes                                                                                          | ⭐ 🔧 |
+| [class-spacing](rules/class-spacing)                       | Disallow extra spacing in class attribute values                                                                            | 🔧    |
+| [element-newline](rules/element-newline)                   | Enforce newline between elements.                                                                                           | ⭐ 🔧 |
+| [id-naming-convention](rules/id-naming-convention)         | Enforce consistent naming of id attributes                                                                                  |       |
+| [indent](rules/indent)                                     | Enforce consistent indentation                                                                                              | ⭐ 🔧 |
+| [lowercase](rules/lowercase)                               | Enforce use of lowercase for tag and attribute names.                                                                       | 🔧    |
+| ~~[no-extra-spacing-attrs](rules/no-extra-spacing-attrs)~~ | ~~Disallow extra spacing around attributes~~ (Deprecated) Use [no-extra-spacing-tags](rules/no-extra-spacing-tags) instead. | ⭐ 🔧 |
+| [no-extra-spacing-tags](rules/no-extra-spacing-tags)       | Disallow extra spacing inside tags                                                                                          | ⭐ 🔧 |
+| [no-extra-spacing-text](rules/no-extra-spacing-text)       | Disallow unnecessary consecutive spaces                                                                                     | 🔧    |
+| [no-multiple-empty-lines](rules/no-multiple-empty-lines)   | Disallow multiple empty lines                                                                                               | 🔧    |
+| [no-trailing-spaces](rules/no-trailing-spaces)             | Disallow trailing whitespace at the end of lines                                                                            | 🔧    |
+| [quotes](rules/quotes)                                     | Enforce consistent quoting attributes with double(") or single(')                                                           | ⭐ 🔧 |
+| [sort-attrs](rules/sort-attrs)                             | Enforce priority and alphabetical sorting of attributes                                                                     | 🔧    |

--- a/docs/rules/no-extra-spacing-attrs.md
+++ b/docs/rules/no-extra-spacing-attrs.md
@@ -5,6 +5,8 @@ description: Disallow extra spacing around attributes for cleaner and more consi
 
 # no-extra-spacing-attrs
 
+> **⚠️ Deprecated**: This rule has been deprecated. Use [`no-extra-spacing-tags`](./no-extra-spacing-tags.md) instead.
+
 This rule disallows extra spaces around attributes and between the start or end of a tag.
 
 ## How to use

--- a/docs/rules/no-extra-spacing-tags.md
+++ b/docs/rules/no-extra-spacing-tags.md
@@ -1,0 +1,143 @@
+---
+title: no-extra-spacing-tags
+description: Disallow extra spacing inside tags.
+---
+
+# no-extra-spacing-tags
+
+This rule disallows extra spaces inside tags, including between attributes and between the tag name and its attributes or closing bracket.
+
+## How to use
+
+```js,.eslintrc.js
+module.exports = {
+  rules: {
+    "@html-eslint/no-extra-spacing-tags": "error",
+  },
+};
+```
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+<!-- prettier-ignore -->
+```html,incorrect
+<!-- an extra space between attributes -->
+<div foo="foo"  bar="bar"></div>
+
+<!-- an extra space between tag start and attribute -->
+<div  foo="foo"></div>
+
+<!-- an extra space between tag end and attribute -->
+<div foo="foo" ></div>
+
+<!-- an extra space between tag start and end -->
+<div ></div>
+```
+
+Examples of **correct** code for this rule:
+
+```html,correct
+<div foo="foo" bar="bar"></div>
+<div foo="foo"></div>
+<div></div>
+```
+
+## Options
+
+- `enforceBeforeSelfClose` (default: false): Enforce exactly one space before self closing tag (`/>`)
+
+Examples of **incorrect** code for this rule with the default `{ "enforceBeforeSelfClose": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<img src="foo.png"  />
+
+<img src="foo.png"/>
+```
+
+<!-- prettier-ignore-end -->
+
+Examples of **correct** code for this rule with the default `{ "enforceBeforeSelfClose": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<img src="foo.png" />
+```
+
+<!-- prettier-ignore-end -->
+
+- `disallowMissing` (default: false): Requires at least one space between attributes (no missing whitespace).
+
+Example(s) of **incorrect** code for this rule with the `{ "disallowMissing": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id="foo"class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+Example(s) of **correct** code for this rule with the `{ "disallowMissing": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id="foo" class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+- `disallowTabs` (default: false): Disallows tabs between attributes; enforces the use of spaces instead.
+
+Example(s) of **incorrect** code for this rule with the `{ "disallowTabs": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div	id="foo"	class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+Example(s) of **correct** code for this rule with the `{ "disallowTabs": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id="foo" class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+- `disallowInAssignment` (default: false): Disallows spaces before or after the `=` in attribute assignments.
+
+Example(s) of **incorrect** code for this rule with the `{ "disallowInAssignment": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id = "foo" class = "bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->
+
+Example(s) of **correct** code for this rule with the `{ "disallowInAssignment": true }` option:
+
+<!-- prettier-ignore-start -->
+
+```html
+<div id="foo" class="bar">
+</div>
+```
+
+<!-- prettier-ignore-end -->

--- a/packages/eslint-plugin/lib/configs/all.js
+++ b/packages/eslint-plugin/lib/configs/all.js
@@ -1,5 +1,7 @@
 const rules = require("../rules");
-const ruleKeys = Object.keys(rules);
+const ruleKeys = Object.entries(rules)
+  .filter(([, rule]) => !rule.meta?.deprecated)
+  .map(([ruleName]) => ruleName);
 
 const allRulesLegacy = ruleKeys.reduce((acc, ruleName) => {
   acc[`@html-eslint/${ruleName}`] = "error";

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -5,7 +5,7 @@ const recommendedRules = {
   "html/require-doctype": "error",
   "html/require-title": "error",
   "html/no-multiple-h1": "error",
-  "html/no-extra-spacing-attrs": "error",
+  "html/no-extra-spacing-tags": "error",
   "html/attrs-newline": "error",
   "html/element-newline": [
     "error",

--- a/packages/eslint-plugin/lib/rules/index.js
+++ b/packages/eslint-plugin/lib/rules/index.js
@@ -6,6 +6,7 @@ const noDuplicateId = require("./no-duplicate-id");
 const noInlineStyles = require("./no-inline-styles");
 const noMultipleH1 = require("./no-multiple-h1");
 const noExtraSpacingAttrs = require("./no-extra-spacing-attrs");
+const noExtraSpacingTags = require("./no-extra-spacing-tags");
 const noExtraSpacingText = require("./no-extra-spacing-text");
 const attrsNewline = require("./attrs-newline");
 const elementNewLine = require("./element-newline");
@@ -73,6 +74,7 @@ const rules = {
   "no-inline-styles": noInlineStyles,
   "no-multiple-h1": noMultipleH1,
   "no-extra-spacing-attrs": noExtraSpacingAttrs,
+  "no-extra-spacing-tags": noExtraSpacingTags,
   "no-extra-spacing-text": noExtraSpacingText,
   "attrs-newline": attrsNewline,
   "element-newline": elementNewLine,

--- a/packages/eslint-plugin/lib/rules/no-extra-spacing-tags.js
+++ b/packages/eslint-plugin/lib/rules/no-extra-spacing-tags.js
@@ -42,14 +42,11 @@ module.exports = {
   meta: {
     type: "code",
 
-    deprecated: true,
-    replacedBy: ["no-extra-spacing-tags"],
-
     docs: {
-      description: "Disallow extra spacing around attributes",
+      description: "Disallow extra spacing inside tags",
       category: RULE_CATEGORY.STYLE,
       recommended: true,
-      url: getRuleUrl("no-extra-spacing-attrs"),
+      url: getRuleUrl("no-extra-spacing-tags"),
     },
 
     fixable: true,

--- a/packages/eslint-plugin/tests/configs.test.js
+++ b/packages/eslint-plugin/tests/configs.test.js
@@ -65,9 +65,12 @@ describe("configs", () => {
   });
 
   test("all legacy rules should be included in the all config", () => {
-    const allExportedRules = Object.keys(exportedRules).map(
-      (name) => `@html-eslint/${name}`
-    );
+    const allExportedRules = Object.entries(exportedRules)
+      .filter(([, rule]) => {
+        return !rule.meta?.deprecated;
+      })
+      .map(([key]) => key)
+      .map((name) => `@html-eslint/${name}`);
     expect(Object.keys(allRulesLegacy)).toEqual(
       expect.arrayContaining(allExportedRules)
     );

--- a/packages/eslint-plugin/tests/configs.test.js
+++ b/packages/eslint-plugin/tests/configs.test.js
@@ -51,7 +51,12 @@ describe("configs", () => {
   test("all recommended rules should be included in the recommended config", () => {
     const recommendedRules = Object.entries(exportedRules)
       .filter(([, rule]) => {
-        return rule.meta && rule.meta.docs && rule.meta.docs.recommended;
+        return (
+          rule.meta &&
+          rule.meta.docs &&
+          rule.meta.docs.recommended &&
+          !rule.meta.deprecated
+        );
       })
       .map(([name]) => `@html-eslint/${name}`);
     expect(Object.keys(recommendedLegacyRules)).toEqual(

--- a/packages/eslint-plugin/tests/rules/no-extra-spacing-tags.test.js
+++ b/packages/eslint-plugin/tests/rules/no-extra-spacing-tags.test.js
@@ -1,0 +1,610 @@
+const createRuleTester = require("../rule-tester");
+const rule = require("../../lib/rules/no-extra-spacing-tags");
+
+const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
+
+ruleTester.run("no-extra-spacing-tags", rule, {
+  valid: [
+    {
+      code: `
+    <html>
+    <body>
+    <div foo="foo" bar="bar"></div>
+    </body>
+    </html>
+    `,
+    },
+    {
+      code: `
+    <html>
+    <body>
+    <div foo = "foo" bar  =  "bar" class\t=\t"baz"></div>
+    </body>
+    </html>
+    `,
+    },
+    {
+      code: '<div foo="foo"\r\nbar="bar"></div>',
+    },
+    {
+      code: `
+  <html>
+<head>
+</head>
+<body>
+  <img src=""/>
+</body>
+</html>`,
+    },
+    {
+      code: `
+  <html>
+<head>
+</head>
+<body>
+  <svg>
+      <circle cx="1"/>
+  </svg>
+</body>
+</html>`,
+    },
+    {
+      code: `
+    <html>
+    <body>
+    <div foo="foo"
+         bar="bar"></div>
+    </body>
+    </html>
+    `,
+    },
+    {
+      code: `
+    <html>
+    <body>
+    <div
+        foo="foo"
+         bar="bar"
+         ></div>
+    </body>
+    </html>
+    `,
+    },
+    // https://github.com/yeonjuan/html-eslint/issues/137
+    {
+      code: "<a target=”_blank” a b c d e f></a>",
+    },
+    {
+      code: "<img />",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+    },
+    {
+      code: "<img\n/>",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+    },
+    {
+      code: "<img src='foo.png' />",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+    },
+    {
+      code: "<img src='foo.png'\n/>",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+    },
+    {
+      code: "<img src='foo.png'/>",
+      options: [
+        {
+          enforceBeforeSelfClose: false,
+        },
+      ],
+    },
+    {
+      code: `<img src='foo.png'alt='foo'/>`,
+    },
+    {
+      code: `<img src='foo.png'alt='foo'/>`,
+      options: [
+        {
+          disallowMissing: false,
+        },
+      ],
+    },
+    {
+      code: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowMissing: true,
+        },
+      ],
+    },
+    {
+      code: `
+\t<div>
+\t\t<img src="foo" />
+\t\t<div foo="bar"></div>
+\t</div>
+`,
+      options: [
+        {
+          disallowMissing: true,
+          disallowTabs: true,
+          enforceBeforeSelfClose: true,
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+    <html>
+    <body>
+    <div foo="foo"  bar="bar"></div>
+    </body>
+    </html>
+    `,
+      output: `
+    <html>
+    <body>
+    <div foo="foo" bar="bar"></div>
+    </body>
+    </html>
+    `,
+      errors: [
+        {
+          messageId: "unexpectedBetween",
+        },
+      ],
+    },
+    {
+      code: `
+    <html>
+    <body>
+    <div foo="foo"  bar="bar"  baz="baz"></div>
+    </body>
+    </html>
+    `,
+      output: `
+    <html>
+    <body>
+    <div foo="foo" bar="bar" baz="baz"></div>
+    </body>
+    </html>
+    `,
+      errors: [
+        {
+          messageId: "unexpectedBetween",
+        },
+        {
+          messageId: "unexpectedBetween",
+        },
+      ],
+    },
+    {
+      code: `
+    <html>
+    <body>
+    <div foo="foo"  bar="bar" baz="baz"  ></div>
+    </body>
+    </html>
+        `,
+      output: `
+    <html>
+    <body>
+    <div foo="foo" bar="bar" baz="baz"></div>
+    </body>
+    </html>
+        `,
+      errors: [
+        {
+          messageId: "unexpectedBetween",
+        },
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: `
+    <html>
+    <body>
+    <div       foo="foo"  bar="bar" baz="baz"  ></div>
+    </body>
+    </html>
+            `,
+      output: `
+    <html>
+    <body>
+    <div foo="foo" bar="bar" baz="baz"></div>
+    </body>
+    </html>
+            `,
+      errors: [
+        {
+          messageId: "unexpectedBefore",
+        },
+        {
+          messageId: "unexpectedBetween",
+        },
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: `
+<html>
+<head>
+</head>
+<body>
+<img src="" />
+</body>
+</html>`,
+      output: `
+<html>
+<head>
+</head>
+<body>
+<img src=""/>
+</body>
+</html>`,
+      errors: [
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: `
+<html>
+<head>
+</head>
+<body>
+<svg>
+<circle cx="1" />
+</svg>
+</body>
+</html>`,
+      output: `
+<html>
+<head>
+</head>
+<body>
+<svg>
+<circle cx="1"/>
+</svg>
+</body>
+</html>`,
+      errors: [
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: "<img src='foo.png' />",
+      output: "<img src='foo.png'/>",
+      errors: [
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: "<a target=”_blank”  a b c d e f></a>",
+      output: "<a target=”_blank” a b c d e f></a>",
+      errors: [
+        {
+          messageId: "unexpectedBetween",
+        },
+      ],
+    },
+    {
+      code: "<img src='foo.png'  />",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      output: "<img src='foo.png' />",
+      errors: [
+        {
+          messageId: "unexpectedBeforeSelfClose",
+        },
+      ],
+    },
+    {
+      code: "<img src='foo.png'/>",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      output: "<img src='foo.png' />",
+      errors: [
+        {
+          messageId: "missingBeforeSelfClose",
+        },
+      ],
+    },
+    {
+      code: "<img/>",
+      output: "<img />",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "missingBeforeSelfClose",
+        },
+      ],
+    },
+    {
+      code: "<img  />",
+      output: "<img />",
+      options: [
+        {
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedBeforeSelfClose",
+        },
+      ],
+    },
+    {
+      code: "<img src='foo.png' />",
+      output: "<img src='foo.png'/>",
+      options: [
+        {
+          enforceBeforeSelfClose: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: `<img src='foo.png'alt='foo'/>`,
+      output: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowMissing: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "missingBefore",
+        },
+      ],
+    },
+    {
+      code: `<img src='foo.png'\talt='foo'/>`,
+      output: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowTabs: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBetween",
+        },
+      ],
+    },
+    {
+      code: `<img\tsrc='foo.png' alt='foo'/>`,
+      output: `<img src='foo.png' alt='foo'/>`,
+      options: [
+        {
+          disallowTabs: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBefore",
+        },
+      ],
+    },
+    {
+      code: `<img\t/>`,
+      output: `<img />`,
+      options: [
+        {
+          disallowTabs: true,
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBeforeSelfClose",
+        },
+      ],
+    },
+    {
+      code: `<div ></div>`,
+      output: `<div></div>`,
+      errors: [
+        {
+          messageId: "unexpectedBeforeClose",
+        },
+      ],
+    },
+    {
+      code: `<div foo="bar" ></div>`,
+      output: `<div foo="bar"></div>`,
+      errors: [
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: `<div\t></div>`,
+      output: `<div></div>`,
+      errors: [
+        {
+          messageId: "unexpectedBeforeClose",
+        },
+      ],
+    },
+    {
+      code: `<div foo="bar"\t></div>`,
+      output: `<div foo="bar"></div>`,
+      errors: [
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: `
+\t<div>
+\t\t<img\tsrc="foo"\t/>
+\t\t<div\tfoo="bar"\tbar="baz"\t></div>
+\t</div>
+`,
+      output: `
+\t<div>
+\t\t<img src="foo" />
+\t\t<div foo="bar" bar="baz"></div>
+\t</div>
+`,
+      options: [
+        {
+          disallowMissing: true,
+          disallowTabs: true,
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedTabBefore",
+        },
+        {
+          messageId: "unexpectedTabBeforeSelfClose",
+        },
+        {
+          messageId: "unexpectedTabBefore",
+        },
+        {
+          messageId: "unexpectedTabBetween",
+        },
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+
+    {
+      code: `
+\t<div   class\t=   "foo"\t\tdata-custom\t\tid\t\t=\t\t"boo">
+\t\t<img\tsrc   =\t"foo"\talt= "name"/>
+\t</div>
+`,
+      output: `
+\t<div class="foo" data-custom id="boo">
+\t\t<img src="foo" alt="name"/>
+\t</div>
+`,
+      options: [
+        {
+          disallowInAssignment: true,
+          disallowTabs: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: "unexpectedBefore",
+        },
+        {
+          messageId: "unexpectedInAssignment",
+        },
+        {
+          messageId: "unexpectedBetween",
+        },
+        {
+          messageId: "unexpectedBetween",
+        },
+        {
+          messageId: "unexpectedInAssignment",
+        },
+        {
+          messageId: "unexpectedTabBefore",
+        },
+        {
+          messageId: "unexpectedInAssignment",
+        },
+        {
+          messageId: "unexpectedTabBetween",
+        },
+        {
+          messageId: "unexpectedInAssignment",
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] no-extra-spacing-tags", rule, {
+  valid: [],
+  invalid: [
+    {
+      code: "html`<div foo='foo'  bar='baz'> </div>`",
+      output: "html`<div foo='foo' bar='baz'> </div>`",
+      errors: [
+        {
+          messageId: "unexpectedBetween",
+        },
+      ],
+    },
+    {
+      code: "html`<div ${foo}  ${bar}> </div>`",
+      output: "html`<div ${foo} ${bar}> </div>`",
+      errors: [
+        {
+          messageId: "unexpectedBetween",
+        },
+      ],
+    },
+    {
+      code: 'html`<div foo="${bar}" > </div>`',
+      output: 'html`<div foo="${bar}"> </div>`',
+      errors: [
+        {
+          messageId: "unexpectedAfter",
+        },
+      ],
+    },
+    {
+      code: "html`<div ${foo}  ${'foo'}> </div>`",
+      output: "html`<div ${foo} ${'foo'}> </div>`",
+      errors: [
+        {
+          messageId: "unexpectedBetween",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/website/.posthtmlrc.js
+++ b/packages/website/.posthtmlrc.js
@@ -20,6 +20,7 @@ Object.entries(rulesRecord).forEach(([rulename, rule]) => {
   rules[rule.meta.docs.category].push([
     rulename,
     "~/src/docs/rules/" + rulename + ".html",
+    !!rule.meta.deprecated,
   ]);
 });
 

--- a/packages/website/scripts/generates/markdowns.js
+++ b/packages/website/scripts/generates/markdowns.js
@@ -40,7 +40,14 @@ async function generateRulesMarkdown() {
     if (rule.meta.docs.recommended) emojis.push("⭐")
     if (rule.meta.fixable) emojis.push("🔧");
     const meta = emojis.join(" ")
-    lines.push(`| [${ruleId}](rules/${ruleId}) | ${rule.meta.docs.description} | ${meta} |`);
+    if (rule.meta.deprecated) {
+      const replacedBy = rule.meta.replacedBy && rule.meta.replacedBy.length
+        ? ` Use ${rule.meta.replacedBy.map((r) => `[${r}](rules/${r})`).join(", ")} instead.`
+        : "";
+      lines.push(`| ~~[${ruleId}](rules/${ruleId})~~ | ~~${rule.meta.docs.description}~~ (Deprecated)${replacedBy} | ${meta} |`);
+    } else {
+      lines.push(`| [${ruleId}](rules/${ruleId}) | ${rule.meta.docs.description} | ${meta} |`);
+    }
   };
 
   lines.push("## Best Practice\n");

--- a/packages/website/src/components/nav-list.html
+++ b/packages/website/src/components/nav-list.html
@@ -11,7 +11,10 @@
         data-nav-active="!border-slate-800 !text-slate-900"
       >
         <a class="w-full no-underline inline-block" href="{{a[1]}}">
-          {{a[0]}}
+          <if condition="a[2]">
+            <s>{{a[0]}} (deprecated)</s>
+          </if>
+          <else>{{a[0]}}</else>
         </a>
       </li>
     </each>


### PR DESCRIPTION
Closes #204

## Summary

Adds a new `no-extra-spacing-tags` rule with identical functionality to `no-extra-spacing-attrs`, and marks the old rule as deprecated per the approach approved by @yeonjuan in #204.

## Changes

- **New rule** `no-extra-spacing-tags` — same logic as `no-extra-spacing-attrs`, updated `meta.docs.description` and `getRuleUrl`
- **Deprecated** `no-extra-spacing-attrs` — `meta.deprecated = true`, `meta.replacedBy = ["no-extra-spacing-tags"]`  
- **Registered** new rule in `packages/eslint-plugin/lib/rules/index.js`
- **Tests** — `no-extra-spacing-tags.test.js` with 44 tests (all passing)
- **Docs** — `docs/rules/no-extra-spacing-tags.md`