### PR TITLE
feat(max-len): add rule to enforce maximum line length

### DIFF
--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -1,0 +1,44 @@
+---
+title: max-len
+description: Enforce a maximum line length in HTML files.
+---
+
+# max-len
+
+This rule enforces a maximum line length to keep HTML readable and consistent across editors and code review tools.
+
+## How to use
+
+```js,.eslintrc.js
+module.exports = {
+  rules: {
+    "@html-eslint/max-len": ["error", { "max": 80 }],
+  },
+};
+```
+
+## Rule Details
+
+This rule reports lines that exceed the configured maximum length.
+
+### Options
+
+- `max` (required): Specifies the maximum line length allowed (number of characters).
+
+Examples of **incorrect** code for this rule with the `{ "max": 80 }` option:
+
+<!-- prettier-ignore -->
+```html,incorrect
+<script crossorigin="anonymous" integrity="sha256-abc123" src="https://cdn.example.com/lib.min.js"></script>
+```
+
+Examples of **correct** code for this rule with the `{ "max": 80 }` option:
+
+<!-- prettier-ignore -->
+```html,correct
+<script
+  crossorigin="anonymous"
+  integrity="sha256-abc123"
+  src="https://cdn.example.com/lib.min.js"
+></script>
+```

--- a/packages/eslint-plugin/lib/rules/index.js
+++ b/packages/eslint-plugin/lib/rules/index.js
@@ -32,6 +32,7 @@ const noMultipleEmptyLines = require("./no-multiple-empty-lines");
 const noAccesskeyAttrs = require("./no-accesskey-attrs");
 const noRestrictedAttrs = require("./no-restricted-attrs");
 const noTrailingSpaces = require("./no-trailing-spaces");
+const maxLen = require("./max-len");
 const requireAttrs = require("./require-attrs");
 const noRestrictedAttrValues = require("./no-restricted-attr-values");
 const noScriptStyleType = require("./no-script-style-type");
@@ -130,6 +131,7 @@ const rules = {
   "no-invalid-attr-value": noInvalidAttrValue,
   "head-order": headOrder,
   "require-details-summary": requireDetailsSummary,
+  "max-len": maxLen,
   // export new rule here ↑
   // DO NOT REMOVE THIS COMMENT
 };

--- a/packages/eslint-plugin/lib/rules/max-len.js
+++ b/packages/eslint-plugin/lib/rules/max-len.js
@@ -1,0 +1,161 @@
+/**
+ * @import {
+ *   CommentContent,
+ *   Text
+ * } from "@html-eslint/types"
+ * @import {RuleModule} from "../types"
+ * @typedef {Object} Option
+ * @property {number} Option.max
+ */
+
+const { parseTemplateLiteral } = require("./utils/template-literal");
+const { RULE_CATEGORY } = require("../constants");
+const {
+  getTemplateTokens,
+  codeToLines,
+  isRangesOverlap,
+} = require("./utils/node");
+const {
+  shouldCheckTaggedTemplateExpression,
+  shouldCheckTemplateLiteral,
+} = require("./utils/settings");
+const { getSourceCode } = require("./utils/source-code");
+const { getRuleUrl } = require("./utils/rule");
+
+const DEFAULT_MAX = 80;
+
+const MESSAGE_IDS = {
+  EXCEED: "exceed",
+};
+
+/** @type {RuleModule<[Option]>} */
+module.exports = {
+  meta: {
+    type: "layout",
+    docs: {
+      description: "Enforce a maximum line length",
+      recommended: false,
+      category: RULE_CATEGORY.STYLE,
+      url: getRuleUrl("max-len"),
+    },
+    fixable: null,
+    schema: [
+      {
+        type: "object",
+        properties: {
+          max: {
+            type: "integer",
+            minimum: 0,
+          },
+        },
+        required: ["max"],
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      [MESSAGE_IDS.EXCEED]:
+        "This line has a length of {{length}}. Maximum allowed is {{max}}.",
+    },
+  },
+
+  create(context) {
+    const max =
+      context.options.length && context.options[0] != null
+        ? context.options[0].max
+        : DEFAULT_MAX;
+
+    const sourceCode = getSourceCode(context);
+
+    /**
+     * @param {string[]} lines
+     * @param {Object} offset
+     * @param {number} offset.line
+     * @param {number} offset.column
+     * @param {(CommentContent | Text)["parts"][number][]} tokens
+     */
+    function check(lines, offset, tokens) {
+      lines.forEach((line, index) => {
+        const lineNumber = index + offset.line;
+        const lineLength = line.length;
+        const columnOffset = index === 0 ? offset.column : 0;
+
+        if (lineLength > max) {
+          const loc = {
+            start: {
+              line: lineNumber,
+              column: max + columnOffset,
+            },
+            end: {
+              line: lineNumber,
+              column: lineLength + columnOffset,
+            },
+          };
+          const start = sourceCode.getIndexFromLoc(loc.start);
+          const end = sourceCode.getIndexFromLoc(loc.end);
+
+          if (
+            tokens.some((token) => isRangesOverlap(token.range, [start, end]))
+          ) {
+            return;
+          }
+
+          context.report({
+            messageId: MESSAGE_IDS.EXCEED,
+            loc,
+            data: {
+              length: `${lineLength}`,
+              max: `${max}`,
+            },
+          });
+        }
+      });
+    }
+
+    return {
+      Document() {
+        check(
+          sourceCode.getLines(),
+          {
+            line: 1,
+            column: 0,
+          },
+          []
+        );
+      },
+      TaggedTemplateExpression(node) {
+        if (shouldCheckTaggedTemplateExpression(node, context)) {
+          const { html, tokens } = parseTemplateLiteral(
+            node.quasi,
+            getSourceCode(context)
+          );
+          const lines = codeToLines(html);
+          check(
+            lines,
+            {
+              line: node.quasi.loc.start.line,
+              column: node.quasi.loc.start.column + 1,
+            },
+            getTemplateTokens(tokens)
+          );
+        }
+      },
+      TemplateLiteral(node) {
+        if (shouldCheckTemplateLiteral(node, context)) {
+          const { html, tokens } = parseTemplateLiteral(
+            node,
+            getSourceCode(context)
+          );
+          const lines = codeToLines(html);
+          check(
+            lines,
+            {
+              line: node.loc.start.line,
+              column: node.loc.start.column + 1,
+            },
+            getTemplateTokens(tokens)
+          );
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/tests/rules/max-len.test.js
+++ b/packages/eslint-plugin/tests/rules/max-len.test.js
@@ -1,0 +1,117 @@
+const createRuleTester = require("../rule-tester");
+const rule = require("../../lib/rules/max-len");
+
+const ruleTester = createRuleTester();
+const templateRuleTester = createRuleTester("espree");
+
+// <div class="XXX"></div> = 12 + XXX + 8 = 20 + XXX
+// 60 a's → 80 chars (at limit)
+// 61 a's → 81 chars (over limit)
+
+ruleTester.run("max-len", rule, {
+  valid: [
+    // exactly at the limit (default 80) — 12 + 60 + 8 = 80
+    {
+      code: `<div class="${"a".repeat(60)}"></div>`,
+      options: [{ max: 80 }],
+    },
+    // short line
+    {
+      code: "<div></div>",
+      options: [{ max: 80 }],
+    },
+    // multi-line, all within limit
+    {
+      code: `<div>\n  <span></span>\n</div>`,
+      options: [{ max: 80 }],
+    },
+    // custom large limit — long line is fine
+    {
+      code: `<div class="${"a".repeat(100)}"></div>`,
+      options: [{ max: 200 }],
+    },
+    // empty document
+    {
+      code: "",
+      options: [{ max: 80 }],
+    },
+  ],
+  invalid: [
+    // single line exceeds: 12 + 61 + 8 = 81 > 80
+    {
+      code: `<div class="${"a".repeat(61)}"></div>`,
+      options: [{ max: 80 }],
+      errors: [
+        {
+          messageId: "exceed",
+          line: 1,
+          column: 81,
+        },
+      ],
+    },
+    // multi-line: line 2 is "  <span class="XXX"></span>"
+    // 15 + 57 + 9 = 81 > 80
+    {
+      code: `<div>\n  <span class="${"a".repeat(57)}"></span>\n</div>`,
+      options: [{ max: 80 }],
+      errors: [
+        {
+          messageId: "exceed",
+          line: 2,
+          column: 81,
+        },
+      ],
+    },
+    // both lines exceed
+    {
+      code: `<div class="${"a".repeat(61)}"></div>\n<span class="${"a".repeat(
+        61
+      )}"></span>`,
+      options: [{ max: 80 }],
+      errors: [
+        {
+          messageId: "exceed",
+          line: 1,
+        },
+        {
+          messageId: "exceed",
+          line: 2,
+        },
+      ],
+    },
+    // custom max=10: any line >10 chars triggers it
+    {
+      code: "<div></div>",
+      options: [{ max: 10 }],
+      errors: [
+        {
+          messageId: "exceed",
+          line: 1,
+          column: 11,
+        },
+      ],
+    },
+  ],
+});
+
+templateRuleTester.run("[template] max-len", rule, {
+  valid: [
+    {
+      code: `html\`<div></div>\``,
+      options: [{ max: 80 }],
+    },
+  ],
+  invalid: [
+    // html`<div class="XXX"></div>` — line is embedded inside template literal
+    // 12 + 61 + 8 = 81 chars in the HTML line
+    {
+      code: `html\`<div class="${"a".repeat(61)}"></div>\``,
+      options: [{ max: 80 }],
+      errors: [
+        {
+          messageId: "exceed",
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Closes #251

Adds a new `max-len` rule that reports HTML lines exceeding a configurable maximum length.

```js
module.exports = {
  rules: {
    "@html-eslint/max-len": ["error", { max: 80 }],
  },
};
```

## What's included

- `lib/rules/max-len.js` — rule implementation
- `tests/rules/max-len.test.js` — 11 tests (valid + invalid + tagged template literal)
- `docs/rules/max-len.md` — documentation with examples

## Notes

- **No autofix** — as discussed in #251, autofix is intentionally omitted for now; it can be added later
- Schema: `{ max: number }` (required)
- Works with both plain HTML documents and tagged template literals (`html\`...\``)
- Reports the excess portion of the line (from column `max+1` to end), so editors highlight exactly what's over the limit
