### PR TITLE
fix(indent): skip indent check for expressions

### DIFF
--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -230,15 +230,16 @@ module.exports = {
      * the line, meaning the line is a template expression continuation rather
      * than an HTML-structural closing line.
      *
-     * For template literal context (ESLint tokens available), additional checks
-     * are applied using ESLint tokens to avoid false positives (e.g. `})}` or
-     * single-token expressions like `${\ncontent}`).
+     * In template literal context, additional ESLint token checks are applied
+     * to avoid false positives (e.g. `})}` or single-token expressions like
+     * `${\ncontent}`).
      *
      * @param {Line} lineNode
      * @param {Text["parts"]} parts
+     * @param {boolean} inTemplateLiteral
      * @returns {boolean}
      */
-    function shouldSkipCloseTemplateLine(lineNode, parts) {
+    function shouldSkipCloseTemplateLine(lineNode, parts, inTemplateLiteral) {
       const sourceLines = sourceCode.getLines();
       for (const part of parts || []) {
         if (
@@ -257,9 +258,9 @@ module.exports = {
         );
         if (!contentBeforeClose.trim()) continue;
 
-        // In template literal context, ESLint tokens are available for more
-        // precise detection to avoid false positives.
-        if (typeof sourceCode.getTokenByRangeStart === "function") {
+        if (inTemplateLiteral) {
+          // In template literal context, use ESLint tokens for precise detection
+          // to avoid false positives (e.g. `})}` or `${\ncontent}`)
           const closeToken = sourceCode.getTokenByRangeStart(
             part.close.range[0]
           );
@@ -295,8 +296,13 @@ module.exports = {
     /**
      * @param {number} baseLevel
      * @param {number} baseSpaces
+     * @param {boolean} [inTemplateLiteral]
      */
-    function createIndentVisitor(baseLevel, baseSpaces) {
+    function createIndentVisitor(
+      baseLevel,
+      baseSpaces,
+      inTemplateLiteral = false
+    ) {
       const indentLevel = new IndentLevel({
         getIncreasingLevel,
       });
@@ -481,7 +487,11 @@ module.exports = {
             if (
               lineNode.hasCloseTemplate &&
               !lineNode.hasOpenTemplate &&
-              shouldSkipCloseTemplateLine(lineNode, node.parts)
+              shouldSkipCloseTemplateLine(
+                lineNode,
+                node.parts,
+                inTemplateLiteral
+              )
             ) {
               return;
             }
@@ -508,7 +518,7 @@ module.exports = {
           parseTemplateLiteral(
             node.quasi,
             getSourceCode(context),
-            createIndentVisitor(base, baseSpaces)
+            createIndentVisitor(base, baseSpaces, true)
           );
         }
       },
@@ -519,7 +529,7 @@ module.exports = {
           parseTemplateLiteral(
             node,
             getSourceCode(context),
-            createIndentVisitor(base, baseSpaces)
+            createIndentVisitor(base, baseSpaces, true)
           );
         }
       },

--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -226,19 +226,20 @@ module.exports = {
 
     /**
      * Returns true when a line with hasCloseTemplate should skip indent check.
-     * Skip when the `}` (CloseTemplate) is NOT the first non-whitespace token
-     * on the line AND the expression contains tokens on earlier lines — meaning
-     * the line is a JavaScript expression continuation (e.g. `"bar"}`), not an
-     * HTML-structural closing sequence like `})}`.
+     * Skip when there is non-whitespace content before the close delimiter on
+     * the line, meaning the line is a template expression continuation rather
+     * than an HTML-structural closing line.
      *
-     * @param {import("../../types").Line} lineNode
-     * @param {(
-     *   | Text
-     *   | import("@html-eslint/types").CommentContent
-     * )["parts"]} parts
+     * For template literal context (ESLint tokens available), additional checks
+     * are applied using ESLint tokens to avoid false positives (e.g. `})}` or
+     * single-token expressions like `${\ncontent}`).
+     *
+     * @param {Line} lineNode
+     * @param {Text["parts"]} parts
      * @returns {boolean}
      */
     function shouldSkipCloseTemplateLine(lineNode, parts) {
+      const sourceLines = sourceCode.getLines();
       for (const part of parts || []) {
         if (
           part.type !== NODE_TYPES.Template ||
@@ -248,35 +249,45 @@ module.exports = {
           continue;
         }
 
-        const closeToken = sourceCode.getTokenByRangeStart(part.close.range[0]);
-        if (!closeToken) continue;
+        // Skip this part if only whitespace precedes the close delimiter on the line
+        const closeLineContent = sourceLines[part.close.loc.start.line - 1];
+        const contentBeforeClose = closeLineContent.slice(
+          0,
+          part.close.loc.start.column
+        );
+        if (!contentBeforeClose.trim()) continue;
 
-        // Walk backward to find the leftmost token on the current line
-        let prevToken = sourceCode.getTokenBefore(closeToken);
-        let firstTokenOnLine = null;
-        while (
-          prevToken &&
-          prevToken.loc.start.line === lineNode.loc.start.line
-        ) {
-          firstTokenOnLine = prevToken;
-          prevToken = sourceCode.getTokenBefore(prevToken);
+        // In template literal context, ESLint tokens are available for more
+        // precise detection to avoid false positives.
+        if (typeof sourceCode.getTokenByRangeStart === "function") {
+          const closeToken = sourceCode.getTokenByRangeStart(
+            part.close.range[0]
+          );
+          if (!closeToken) continue;
+
+          // Walk backward to find the leftmost token on the current line
+          let prevToken = sourceCode.getTokenBefore(closeToken);
+          let firstTokenOnLine = null;
+          while (
+            prevToken &&
+            prevToken.loc.start.line === lineNode.loc.start.line
+          ) {
+            firstTokenOnLine = prevToken;
+            prevToken = sourceCode.getTokenBefore(prevToken);
+          }
+
+          // No token before close delimiter → it is first → don't skip
+          if (!firstTokenOnLine) continue;
+
+          // Line starts with the same value as the close delimiter (e.g. `})}`) → don't skip
+          if (firstTokenOnLine.value === part.close.value) continue;
+
+          // If prevToken is a Template delimiter, firstTokenOnLine is the only
+          // expression token — don't skip (e.g. `${\ncontent}`)
+          if (!prevToken || prevToken.type === "Template") continue;
         }
 
-        // No token before } on this line → } is first → don't skip
-        if (!firstTokenOnLine) continue;
-
-        // Line starts with the same token as the close delimiter (e.g. `})}`) → don't skip
-        if (firstTokenOnLine.value === part.close.value) continue;
-
-        // Check if the expression has tokens on earlier lines.
-        // After the loop, prevToken is either null, a Template delimiter
-        // (TemplateHead/TemplateMiddle), or a non-Template token from an
-        // earlier line inside the expression.
-        // If it's a Template token, firstTokenOnLine is the only expression
-        // token, so we should not skip (e.g. `${` then `content}` on next line).
-        if (prevToken && prevToken.type !== "Template") {
-          return true;
-        }
+        return true;
       }
       return false;
     }
@@ -284,13 +295,8 @@ module.exports = {
     /**
      * @param {number} baseLevel
      * @param {number} baseSpaces
-     * @param {boolean} [inTemplateLiteral]
      */
-    function createIndentVisitor(
-      baseLevel,
-      baseSpaces,
-      inTemplateLiteral = false
-    ) {
+    function createIndentVisitor(baseLevel, baseSpaces) {
       const indentLevel = new IndentLevel({
         getIncreasingLevel,
       });
@@ -473,7 +479,6 @@ module.exports = {
               return;
             }
             if (
-              inTemplateLiteral &&
               lineNode.hasCloseTemplate &&
               !lineNode.hasOpenTemplate &&
               shouldSkipCloseTemplateLine(lineNode, node.parts)
@@ -503,7 +508,7 @@ module.exports = {
           parseTemplateLiteral(
             node.quasi,
             getSourceCode(context),
-            createIndentVisitor(base, baseSpaces, true)
+            createIndentVisitor(base, baseSpaces)
           );
         }
       },
@@ -514,7 +519,7 @@ module.exports = {
           parseTemplateLiteral(
             node,
             getSourceCode(context),
-            createIndentVisitor(base, baseSpaces, true)
+            createIndentVisitor(base, baseSpaces)
           );
         }
       },

--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -136,7 +136,6 @@ module.exports = {
   create(context) {
     const sourceCode = getSourceCode(context);
     const indentLevelOptions = (context.options && context.options[1]) || {};
-    const CLOSING_PUNCTUATORS = ["}", ")", "]"];
     const lines = sourceCode.getLines();
     const ignoreComment = indentLevelOptions.ignoreComment === true;
     const autoBaseIndent = indentLevelOptions.templateIndentBase === "first";
@@ -248,6 +247,7 @@ module.exports = {
         ) {
           continue;
         }
+
         const closeToken = sourceCode.getTokenByRangeStart(part.close.range[0]);
         if (!closeToken) continue;
 
@@ -265,8 +265,8 @@ module.exports = {
         // No token before } on this line → } is first → don't skip
         if (!firstTokenOnLine) continue;
 
-        // Line starts with a closing bracket (e.g. `})}`) → don't skip
-        if (CLOSING_PUNCTUATORS.includes(firstTokenOnLine.value)) continue;
+        // Line starts with the same token as the close delimiter (e.g. `})}`) → don't skip
+        if (firstTokenOnLine.value === part.close.value) continue;
 
         // Check if the expression has tokens on earlier lines.
         // After the loop, prevToken is either null, a Template delimiter

--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -50,6 +50,7 @@ const {
   isScript,
   isStyle,
   isText,
+  isRangesOverlap,
 } = require("../utils/node");
 const {
   shouldCheckTaggedTemplateExpression,
@@ -135,6 +136,7 @@ module.exports = {
   create(context) {
     const sourceCode = getSourceCode(context);
     const indentLevelOptions = (context.options && context.options[1]) || {};
+    const CLOSING_PUNCTUATORS = ["}", ")", "]"];
     const lines = sourceCode.getLines();
     const ignoreComment = indentLevelOptions.ignoreComment === true;
     const autoBaseIndent = indentLevelOptions.templateIndentBase === "first";
@@ -224,10 +226,71 @@ module.exports = {
     }
 
     /**
+     * Returns true when a line with hasCloseTemplate should skip indent check.
+     * Skip when the `}` (CloseTemplate) is NOT the first non-whitespace token
+     * on the line AND the expression contains tokens on earlier lines — meaning
+     * the line is a JavaScript expression continuation (e.g. `"bar"}`), not an
+     * HTML-structural closing sequence like `})}`.
+     *
+     * @param {import("../../types").Line} lineNode
+     * @param {(
+     *   | Text
+     *   | import("@html-eslint/types").CommentContent
+     * )["parts"]} parts
+     * @returns {boolean}
+     */
+    function shouldSkipCloseTemplateLine(lineNode, parts) {
+      for (const part of parts || []) {
+        if (
+          part.type !== NODE_TYPES.Template ||
+          !part.close ||
+          !isRangesOverlap(part.close.range, lineNode.range)
+        ) {
+          continue;
+        }
+        const closeToken = sourceCode.getTokenByRangeStart(part.close.range[0]);
+        if (!closeToken) continue;
+
+        // Walk backward to find the leftmost token on the current line
+        let prevToken = sourceCode.getTokenBefore(closeToken);
+        let firstTokenOnLine = null;
+        while (
+          prevToken &&
+          prevToken.loc.start.line === lineNode.loc.start.line
+        ) {
+          firstTokenOnLine = prevToken;
+          prevToken = sourceCode.getTokenBefore(prevToken);
+        }
+
+        // No token before } on this line → } is first → don't skip
+        if (!firstTokenOnLine) continue;
+
+        // Line starts with a closing bracket (e.g. `})}`) → don't skip
+        if (CLOSING_PUNCTUATORS.includes(firstTokenOnLine.value)) continue;
+
+        // Check if the expression has tokens on earlier lines.
+        // After the loop, prevToken is either null, a Template delimiter
+        // (TemplateHead/TemplateMiddle), or a non-Template token from an
+        // earlier line inside the expression.
+        // If it's a Template token, firstTokenOnLine is the only expression
+        // token, so we should not skip (e.g. `${` then `content}` on next line).
+        if (prevToken && prevToken.type !== "Template") {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /**
      * @param {number} baseLevel
      * @param {number} baseSpaces
+     * @param {boolean} [inTemplateLiteral]
      */
-    function createIndentVisitor(baseLevel, baseSpaces) {
+    function createIndentVisitor(
+      baseLevel,
+      baseSpaces,
+      inTemplateLiteral = false
+    ) {
       const indentLevel = new IndentLevel({
         getIncreasingLevel,
       });
@@ -409,6 +472,14 @@ module.exports = {
             ) {
               return;
             }
+            if (
+              inTemplateLiteral &&
+              lineNode.hasCloseTemplate &&
+              !lineNode.hasOpenTemplate &&
+              shouldSkipCloseTemplateLine(lineNode, node.parts)
+            ) {
+              return;
+            }
             if (lineNode.value.trim().length) {
               visitedTextLines.push(lineNode.loc.start.line);
               checkIndent(lineNode);
@@ -432,7 +503,7 @@ module.exports = {
           parseTemplateLiteral(
             node.quasi,
             getSourceCode(context),
-            createIndentVisitor(base, baseSpaces)
+            createIndentVisitor(base, baseSpaces, true)
           );
         }
       },
@@ -443,7 +514,7 @@ module.exports = {
           parseTemplateLiteral(
             node,
             getSourceCode(context),
-            createIndentVisitor(base, baseSpaces)
+            createIndentVisitor(base, baseSpaces, true)
           );
         }
       },

--- a/packages/eslint-plugin/lib/rules/indent/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent/indent.js
@@ -283,9 +283,17 @@ module.exports = {
           // Line starts with the same value as the close delimiter (e.g. `})}`) → don't skip
           if (firstTokenOnLine.value === part.close.value) continue;
 
-          // If prevToken is a Template delimiter, firstTokenOnLine is the only
-          // expression token — don't skip (e.g. `${\ncontent}`)
-          if (!prevToken || prevToken.type === "Template") continue;
+          // If prevToken starts before the expression opened, it is the
+          // enclosing template literal — firstTokenOnLine is the only
+          // expression token, so don't skip (e.g. `${\ncontent}`).
+          // Nested templates inside the expression have range[0] after
+          // part.open.range[1] and are not caught by this check.
+          if (
+            !prevToken ||
+            !part.open ||
+            prevToken.range[0] < part.open.range[1]
+          )
+            continue;
         }
 
         return true;

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -1831,6 +1831,7 @@ true,
     \${when(
       true,
       () => html\`
+        <div></div>
 \`)}
   </div>
 \``,

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -1769,6 +1769,50 @@ true,
 \`;`,
       options: [2, { templateIndentBase: "first" }],
     },
+    {
+      code: `html\`
+\${when(
+true,
+() => html\`
+\${when(
+true,
+() => html\`
+<ul
+  class="list"
+>
+  <li>item1</li>
+  <li>item2</li>
+</ul>
+\`)}
+<div
+  class="wrapper"
+>
+  <p>text</p>
+</div>
+\`)}
+<footer
+  class="main-footer"
+>
+  <span>footer</span>
+</footer>
+\`;`,
+      options: [2, { templateIndentBase: "first" }],
+    },
+    {
+      code: `html\`
+\${when(
+true,
+() => html\`
+<div
+  class="\${cls}"
+  id="\${id}"
+>
+  <p>text</p>
+</div>
+\`)}
+\`;`,
+      options: [2, { templateIndentBase: "first" }],
+    },
   ],
   invalid: [
     {
@@ -2320,6 +2364,34 @@ true,
 \`;`,
       options: [2, { templateIndentBase: "first" }],
       errors: wrongIndentErrors(4),
+    },
+    {
+      code: `html\`
+\${when(
+true,
+() => html\`
+<div
+class="wrapper"
+  id="main"
+>
+  <p>text</p>
+</div>
+\`)}
+\`;`,
+      output: `html\`
+\${when(
+true,
+() => html\`
+<div
+  class="wrapper"
+  id="main"
+>
+  <p>text</p>
+</div>
+\`)}
+\`;`,
+      options: [2, { templateIndentBase: "first" }],
+      errors: wrongIndentErrors(1),
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -1601,6 +1601,18 @@ const code = html\`
  }
       `,
     },
+    {
+      code: `
+html\`
+    <div>
+        \${
+		
+  			a ? "foo":
+          "bar"}
+    </div>
+\`
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -1606,12 +1606,40 @@ const code = html\`
 html\`
     <div>
         \${
-		
+
   			a ? "foo":
           "bar"}
     </div>
 \`
       `,
+    },
+    {
+      code: `html\`
+    <div>
+        \${
+          condition
+            ? valueA
+            : valueB}
+    </div>
+      \``,
+    },
+    {
+      code: `html\`
+    <div>
+        \${
+          a ||
+              b}
+    </div>
+      \``,
+    },
+    {
+      code: `html\`
+    <div>
+        \${
+          "prefix" +
+            "suffix"}
+    </div>
+      \``,
     },
   ],
   invalid: [

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -1825,6 +1825,17 @@ true,
 \`;`,
       options: [2],
     },
+    {
+      code: `html\`
+  <div>
+    \${when(
+      true,
+      () => html\`
+\`)}
+  </div>
+\``,
+      options: [2],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -1813,6 +1813,18 @@ true,
 \`;`,
       options: [2, { templateIndentBase: "first" }],
     },
+    {
+      code: `html\`
+  <div>
+    \${
+  foo(
+    condition
+      ? html\`<div class="bar"></div>\`
+: html\`<div class="baz"></div>\`)}
+  </div>
+\`;`,
+      options: [2],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -1731,6 +1731,44 @@ html\`
     </div>
       \``,
     },
+    {
+      code: `html\`
+  \${when(
+      true,
+      () => html\`
+        <b>ok</b>
+      \`)}
+\`;`,
+      options: [2],
+    },
+    {
+      code: `html\`
+  \${when(
+      true,
+      () => html\`
+        \${when(
+            true,
+            () => html\`
+              <b>ok</b>
+            \`)}
+      \`)}
+\`;`,
+      options: [2],
+    },
+    {
+      code: `html\`
+\${when(
+true,
+() => html\`
+\${when(
+true,
+() => html\`
+<b>ok</b>
+\`)}
+\`)}
+\`;`,
+      options: [2, { templateIndentBase: "first" }],
+    },
   ],
   invalid: [
     {
@@ -2015,7 +2053,7 @@ class Component extends LitElement {
           [],
           item => html\`
             <p>content</p>
-      \`)}
+          \`)}
       \${
         repeat(
             [],
@@ -2028,7 +2066,7 @@ class Component extends LitElement {
 }
       `,
       options: [2],
-      errors: wrongIndentErrors(2),
+      errors: wrongIndentErrors(1),
     },
     {
       code: `
@@ -2210,6 +2248,78 @@ const code = html\`
     -->
       \``,
       errors: wrongIndentErrors(1),
+    },
+    {
+      code: `html\`
+\${when(
+true,
+() => html\`
+\${when(
+true,
+() => html\`
+<b>
+<div></div>
+</b>
+\`)}
+\`)}
+\`;`,
+      output: `html\`
+\${when(
+true,
+() => html\`
+\${when(
+true,
+() => html\`
+<b>
+  <div></div>
+</b>
+\`)}
+\`)}
+\`;`,
+      options: [2, { templateIndentBase: "first" }],
+      errors: wrongIndentErrors(1),
+    },
+    {
+      code: `html\`
+<div>
+\${when(
+true,
+() => html\`
+\${when(
+true,
+() => html\`
+<b>
+<div></div>
+</b>
+\`)}
+<div>
+ <span></span>
+</div>
+\`)}
+<span></span>
+</div>
+\`;`,
+      output: `html\`
+<div>
+  \${when(
+true,
+() => html\`
+\${when(
+true,
+() => html\`
+<b>
+  <div></div>
+</b>
+\`)}
+<div>
+  <span></span>
+</div>
+\`)}
+  <span></span>
+</div>
+\`;`,
+      options: [2, { templateIndentBase: "first" }],
+      errors: wrongIndentErrors(4),
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/indent.test.js
+++ b/packages/eslint-plugin/tests/rules/indent.test.js
@@ -542,6 +542,52 @@ comment
           },
         ],
       },
+      {
+        code: `
+<div>
+    <% content %>
+</div>
+        `,
+        languageOptions: {
+          parserOptions: {
+            templateEngineSyntax: {
+              "<%": "%>",
+            },
+          },
+        },
+      },
+      {
+        code: `
+<div>
+    <%
+      content
+    %>
+</div>
+        `,
+        languageOptions: {
+          parserOptions: {
+            templateEngineSyntax: {
+              "<%": "%>",
+            },
+          },
+        },
+      },
+      {
+        code: `
+<div>
+    <%
+      content
+      content %>
+</div>
+        `,
+        languageOptions: {
+          parserOptions: {
+            templateEngineSyntax: {
+              "<%": "%>",
+            },
+          },
+        },
+      },
     ],
     invalid: [
       {
@@ -1395,6 +1441,50 @@ text
         },
       },
       {
+        code: `
+<div>
+<% content %>
+</div>
+        `,
+        errors: wrongIndentErrors(1),
+        output: `
+<div>
+    <% content %>
+</div>
+        `,
+        languageOptions: {
+          parserOptions: {
+            templateEngineSyntax: {
+              "<%": "%>",
+            },
+          },
+        },
+      },
+      {
+        code: `
+<div>
+<%
+  content
+%>
+</div>
+        `,
+        errors: wrongIndentErrors(2),
+        output: `
+<div>
+    <%
+  content
+    %>
+</div>
+        `,
+        languageOptions: {
+          parserOptions: {
+            templateEngineSyntax: {
+              "<%": "%>",
+            },
+          },
+        },
+      },
+      {
         code: `<div>
 <div></div>
 </div>
@@ -2047,6 +2137,22 @@ const code = html\`
 const code = html\`
  <div>
      id="\${bar}">
+ </div>\`;
+    `,
+      options: [4, { templateIndentBase: "first" }],
+      errors: wrongIndentErrors(1),
+    },
+    {
+      code: `
+const code = html\`
+ <div>
+\${child}
+ </div>\`;
+    `,
+      output: `
+const code = html\`
+ <div>
+     \${child}
  </div>\`;
     `,
       options: [4, { templateIndentBase: "first" }],


### PR DESCRIPTION
## Summary
- fixes #586
- Fixes false positives in the `indent` rule where lines ending with the closing `}` of a template expression were incorrectly checked for HTML indentation when JavaScript expression content preceded the `}` on that line.

## Details

**Before:** The rule incorrectly reported indentation errors on JS expression continuation lines:

```js
html`
  <div>
    ${a ? "foo"
        : "bar"}   // ← false positive
  </div>
`
```

Lines inside nested template literals also triggered false positives:

```js
html`
  ${when(true, () => html`
    <b>ok</b>
  `)}            // ← false positive
`
```

**After:** Both cases are correctly skipped.

### Algorithm (`shouldSkipCloseTemplateLine`)

Walks backward from the CloseTemplate token to find the leftmost token on the same line:

1. **No token before `}` on the line** → check (no skip).
2. **First token matches the close delimiter** (e.g. `}` in `})}`) → structural closing → check (no skip).
3. **Previous token starts before the expression opened** (`prevToken.range[0] < part.open.range[1]`) → single-token expression like `${\ncontent}` → check (no skip).
4. **Otherwise** → multi-line expression continuation or nested template → skip.

## Test plan
- [x] Multi-line ternary, logical OR, string concatenation continuation lines: skip ✓
- [x] Nested tagged template literals (`html\`...\`)}`) at 2 and 3 levels deep: skip ✓
- [x] Attributes and attribute expressions in nested templates: skip ✓
- [x] `${\ncontent}` (single-token expression): still checked ✓
- [x] `})}` (structural closing): still checked ✓
- [x] Template engine syntax (`<% %>`) unaffected ✓
- [x] Legacy ESLint config mode (`yarn test:legacy`): passing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)