### PR TITLE
feat: handle logical branches in templatse

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=lf
 /.yarn/**            linguist-vendored
 /.yarn/releases/*    binary
 /.yarn/plugins/**/*  binary

--- a/docs/integrating-template-engine.md
+++ b/docs/integrating-template-engine.md
@@ -1,6 +1,6 @@
 ---
 title: Integrating Template Engine
-description: Learn how to integrate HTML ESLint with template engines like Handlebars, Twig, and ERB using parser options and presets.
+description: Learn how to integrate HTML ESLint with template engines like Handlebars, Twig, Nunjucks, and ERB using parser options and presets.
 ---
 
 # Integrating Template Engine with HTML ESLint Plugin
@@ -78,30 +78,111 @@ module.exports = [
 
 ## Using Presets
 
-To simplify the setup, the plugin provides built-in presets for common template engines. You can enable these presets by importing them from @html-eslint/parser:
+To simplify the setup, the plugin provides built-in presets for common template engines. You can enable these presets by importing them from `@html-eslint/parser`:
 
 ```js
 const { TEMPLATE_ENGINE_SYNTAX } = require("@html-eslint/parser");
 
-// Handlebars integration
+// Handlebars
 parserOptions: {
   templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.HANDLEBAR;
 }
 
-// Twig.js integration
+// Handlebars with branch-aware duplicate checking (recommended — see below)
+parserOptions: {
+  templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.HANDLEBAR_EXTENDED;
+}
+
+// Twig
 parserOptions: {
   templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG;
 }
 
-// ERB integration
+// Nunjucks
+parserOptions: {
+  templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.NUNJUCKS;
+}
+
+// ERB
 parserOptions: {
   templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.ERB;
 }
 ```
 
+## Branch-Aware Duplicate Checking
+
+Rules such as `html/no-duplicate-id`, `html/no-duplicate-attrs`, and `html/no-duplicate-in-head` normally report an error whenever the same id, attribute, or head tag appears more than once in a file. This is usually correct, but it produces false positives when the duplicates are inside mutually exclusive template branches — a pattern that is common and intentional:
+
+```twig
+<p>
+  {% if result is same as(null) %}
+    <span id="status"></span>
+  {% elseif result is same as(false) %}
+    <span id="status" class="failure">Invalid</span>
+  {% else %}
+    <span id="status" class="success">Valid</span>
+  {% endif %}
+</p>
+```
+
+In the example above all three `<span id="status">` elements are in different branches of the same `{% if %}` block, so only one of them can ever be present in the rendered HTML at a time. This is not a real duplicate.
+
+The presets listed in the table below include branch pattern configuration that teaches the parser which template tokens open, continue, and close a conditional block. When branch information is available, the duplicate-checking rules automatically suppress errors for nodes that are confined to mutually exclusive branches.
+
+| Preset | Branch-aware |
+|---|---|
+| `TWIG` | ✓ |
+| `NUNJUCKS` | ✓ |
+| `HANDLEBAR_EXTENDED` | ✓ |
+| `HANDLEBAR` | ✗ |
+| `ERB` | ✗ |
+
+`HANDLEBAR` is kept for backwards compatibility. `HANDLEBAR_EXTENDED` is the recommended preset for Handlebars projects going forward.
+
+`ERB` does not support branch-awareness because ERB's `end` keyword closes every block type — `if`, `unless`, `while`, `each`, and any custom iterator — making it impossible to reliably detect conditional branches without a full Ruby parser.
+
+## Custom Branch Configuration
+
+If you are using a template engine that is not covered by a built-in preset, or if you have customized the delimiters of a supported engine, you can provide branch patterns manually.
+
+Branch configuration is supplied as the `branch` property of a `SyntaxConfigItem`. It must use the array form of `templateEngineSyntax` (not the `{ "open": "close" }` shorthand, which has no place to carry extra properties):
+
+```js
+parserOptions: {
+  templateEngineSyntax: [
+    {
+      open: "{%",
+      close: "%}",
+      branch: {
+        // Matches the content of tokens that open a new conditional block.
+        start: /^\s*if\b/,
+        // Matches the content of tokens that separate branches (else / elseif).
+        continue: /^\s*(elseif|else)\b/,
+        // Matches the content of tokens that close the conditional block.
+        end: /^\s*endif\b/,
+        // Optional: matches tokens that open other block types which may
+        // themselves contain an else clause (e.g. for, macro).
+        // Without this, an else inside a for-loop could be mistaken for
+        // the else of an enclosing if-block.
+        blockOpen: /^\s*(for|block|macro)\b/,
+        // Optional: matches the closing tokens for those other block types.
+        blockClose: /^\s*end(for|block|macro)\b/,
+      },
+    },
+    // Additional delimiter pairs without branch config are listed normally:
+    { open: "{{", close: "}}" },
+    { open: "{#", close: "#}", isComment: true },
+  ]
+}
+```
+
+All patterns are matched against the raw content between the opening and closing delimiters of each template token. For example, the content of `{% if condition %}` is ` if condition ` (including surrounding whitespace), so a pattern of `/^\s*if\b/` matches it correctly.
+
+`blockOpen` and `blockClose` are optional but strongly recommended for any engine where block constructs other than `if` can contain their own `else`. Omitting them may cause a false suppression of a real duplicate error if an `else` belonging to a `for` loop is misread as the `else` of an enclosing `if`.
+
 ## Skip frontmatter
 
-If you are using frontmatter in html, set the parser options to `"frontmatter": true`, which tells the plugin to ignore the frontmatter part. (default: `false`)
+If you are using frontmatter in HTML, set the parser option `"frontmatter": true`, which tells the plugin to ignore the frontmatter part. (default: `false`)
 
 ```js
 parserOptions: {
@@ -121,7 +202,7 @@ languageOptions: {
 }
 ```
 
-In this example, the content inside <markdown> tags will be treated as raw text:
+In this example, the content inside `<markdown>` tags will be treated as raw text:
 
 ```html
 <markdown>
@@ -129,4 +210,4 @@ In this example, the content inside <markdown> tags will be treated as raw text:
 </markdown>
 ```
 
-Without rawContentTags, the parser may interpret `<></>` as invalid HTML syntax. With `rawContentTags: ["markdown"]`, the entire content inside `<markdown>` is preserved as plain text.
+Without `rawContentTags`, the parser may interpret `<></>` as invalid HTML syntax. With `rawContentTags: ["markdown"]`, the entire content inside `<markdown>` is preserved as plain text.

--- a/docs/integrating-template-engine.md
+++ b/docs/integrating-template-engine.md
@@ -129,13 +129,13 @@ In the example above all three `<span id="status">` elements are in different br
 
 The presets listed in the table below include branch pattern configuration that teaches the parser which template tokens open, continue, and close a conditional block. When branch information is available, the duplicate-checking rules automatically suppress errors for nodes that are confined to mutually exclusive branches.
 
-| Preset | Branch-aware |
-|---|---|
-| `TWIG` | ✓ |
-| `NUNJUCKS` | ✓ |
-| `HANDLEBAR_EXTENDED` | ✓ |
-| `HANDLEBAR` | ✗ |
-| `ERB` | ✗ |
+| Preset               | Branch-aware |
+| -------------------- | ------------ |
+| `TWIG`               | ✓            |
+| `NUNJUCKS`           | ✓            |
+| `HANDLEBAR_EXTENDED` | ✓            |
+| `HANDLEBAR`          | ✗            |
+| `ERB`                | ✗            |
 
 `HANDLEBAR` is kept for backwards compatibility. `HANDLEBAR_EXTENDED` is the recommended preset for Handlebars projects going forward.
 
@@ -172,11 +172,11 @@ parserOptions: {
     // Additional delimiter pairs without branch config are listed normally:
     { open: "{{", close: "}}" },
     { open: "{#", close: "#}", isComment: true },
-  ]
+  ];
 }
 ```
 
-All patterns are matched against the raw content between the opening and closing delimiters of each template token. For example, the content of `{% if condition %}` is ` if condition ` (including surrounding whitespace), so a pattern of `/^\s*if\b/` matches it correctly.
+All patterns are matched against the raw content between the opening and closing delimiters of each template token. For example, the content of `{% if condition %}` is `if condition` (including surrounding whitespace), so a pattern of `/^\s*if\b/` matches it correctly.
 
 `blockOpen` and `blockClose` are optional but strongly recommended for any engine where block constructs other than `if` can contain their own `else`. Omitting them may cause a false suppression of a real duplicate error if an `else` belonging to a `for` loop is misread as the `else` of an enclosing `if`.
 

--- a/packages/eslint-plugin/lib/rules/no-duplicate-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-attrs.js
@@ -71,7 +71,7 @@ module.exports = {
     function check(node) {
       if (!Array.isArray(node.attributes)) return;
 
-      // Maps a normalised attribute key to the list of attribute nodes for
+      // Maps a normalized attribute key to the list of attribute nodes for
       // that key that have NOT yet been reported as duplicates.
       //
       // Invariant: every pair of nodes in any list is mutually exclusive

--- a/packages/eslint-plugin/lib/rules/no-duplicate-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-attrs.js
@@ -11,12 +11,14 @@
  * } from "../types"
  */
 
+const { NODE_TYPES } = require("@html-eslint/parser");
 const { RULE_CATEGORY } = require("../constants");
 const { createVisitors } = require("./utils/visitors");
 const { getRuleUrl } = require("./utils/rule");
-const { hasTemplate } = require("./utils/node");
 const {
   getBranchSegments,
+  getControlTokenRanges,
+  isControlToken,
   areInMutuallyExclusiveBranches,
 } = require("./utils/branch-segments");
 
@@ -50,31 +52,105 @@ module.exports = {
 
   create(context) {
     const branchSegments = getBranchSegments(context);
+    const controlTokenRanges = getControlTokenRanges(context);
 
     /**
      * @param {Attribute} node
+     * @param {string} attrName
      * @returns {SuggestionReportDescriptor[]}
      */
-    function getSuggestions(node) {
+    function getSuggestions(node, attrName) {
       return [
         {
           messageId: MESSAGE_IDS.REMOVE_ATTR,
           fix: (fixer) => fixer.removeRange(node.range),
           data: {
-            attrName: node.key.value,
+            attrName,
           },
         },
       ];
+    }
+
+    /**
+     * Determine the attribute's effective (template-stripped) name and a source
+     * position safe to use for branch-exclusivity comparison.
+     *
+     * When a template engine is configured, a template token with no separating
+     * whitespace gets glued onto the following node's text by es-html-parser —
+     * e.g. `{%if x%}data-id="1"` produces a key whose raw `.value` is `"{%if
+     * x%}data-id"`, not `"data-id"`. Using that raw value would mean the same
+     * logical attribute name never compares equal across branches, and using
+     * the whole Attribute node's `.range` for position would place it _before_
+     * the branch segment starts (since the glued token's start becomes the
+     * node's start). Both would defeat branch exclusivity detection entirely,
+     * independent of whether the source happens to have a space after the token
+     * — but real template engines (Twig included) do not require one.
+     *
+     * `attr.key.parts` splits the key into `Part` entries (real text) and
+     * `Template` entries (embedded template tokens). We reconstruct the real
+     * name from the `Part` entries and use the first `Part` entry's position
+     * for comparisons — a position that always falls inside the branch content,
+     * regardless of spacing.
+     *
+     * This is only safe when every `Template` entry glued into the key is a
+     * recognized branch-control token (`{% if %}`, `{% else %}`, `{% endif %}`,
+     * etc.) — a structural marker whose presence doesn't change the attribute
+     * name itself. If a `Template` entry is a plain value-interpolation token
+     * instead (e.g. `data-{{name}}`), the attribute name is genuinely dynamic
+     * and can't be safely compared at all, so the whole attribute is skipped,
+     * matching the rule's original conservative behavior for such cases.
+     *
+     * @param {Attribute} attr
+     * @returns {{ key: string; displayName: string; pos: number } | null}
+     */
+    function getComparable(attr) {
+      const parts = attr.key.parts || [];
+
+      if (parts.length === 0) {
+        // No template involvement in the key at all — the common case.
+        return {
+          key: attr.key.value.toLowerCase(),
+          displayName: attr.key.value,
+          pos: attr.range[0],
+        };
+      }
+
+      const partEntries = parts.filter((p) => p.type === NODE_TYPES.Part);
+      const templateEntries = parts.filter((p) => p.type !== NODE_TYPES.Part);
+
+      const allGluedTokensAreControlTokens = templateEntries.every((t) =>
+        isControlToken(t.range, controlTokenRanges)
+      );
+      if (!allGluedTokensAreControlTokens) {
+        // At least one embedded template token is a genuine value
+        // interpolation (e.g. `data-{{name}}`) rather than a structural
+        // if/else/endif marker — the name is dynamic and can't be compared.
+        return null;
+      }
+
+      if (partEntries.length === 0) {
+        // The "attribute" is entirely template syntax with no real name at
+        // all (e.g. es-html-parser exposing a bare `{% endif %}` as its own
+        // pseudo-attribute). Not a genuine attribute — nothing to compare.
+        return null;
+      }
+
+      const displayName = partEntries.map((p) => p.value).join("");
+      return {
+        key: displayName.toLowerCase(),
+        displayName,
+        pos: partEntries[0].range[0],
+      };
     }
 
     /** @param {Tag | StyleTag | ScriptTag} node */
     function check(node) {
       if (!Array.isArray(node.attributes)) return;
 
-      // Maps a normalized attribute key to the list of attribute nodes for
-      // that key that have NOT yet been reported as duplicates.
+      // Maps a normalized attribute name to the list of { attr, pos } entries
+      // for that name that have NOT yet been reported as duplicates.
       //
-      // Invariant: every pair of nodes in any list is mutually exclusive
+      // Invariant: every pair of entries in any list is mutually exclusive
       // (they live in different branches of the same template if-block).
       //
       // When a new occurrence arrives we check it against the whole stored
@@ -84,44 +160,50 @@ module.exports = {
       //
       // This list-based approach correctly handles edge cases such as:
       //
-      //   <span {%- if c1 -%}class="a"{%- else -%}class="b"{%- endif -%}
-      //         {%- if c1 -%}class="c"{%- endif -%}>
+      //   <span {% if c1 %} class="a"{% else %} class="b"{% endif %}
+      //         {% if c1 %} class="c"{% endif %}>
       //
       // where class[a] and class[c] (both in the same branch) are real
       // duplicates even though class[a]/class[b] and class[b]/class[c] are
       // individually exclusive.
-      /** @type {Map<string, Attribute[]>} */
+      /** @type {Map<string, { attr: Attribute; pos: number }[]>} */
       const attrsMap = new Map();
 
       node.attributes.forEach((attr) => {
-        if (hasTemplate(attr.key)) {
-          return;
-        }
-        const key = attr.key.value.toLowerCase();
+        const comparable = getComparable(attr);
+        if (!comparable) return;
+        const { key, displayName, pos } = comparable;
 
         if (attrsMap.has(key)) {
-          const prevList = /** @type {Attribute[]} */ (attrsMap.get(key));
+          const prevList = /** @type {{ attr: Attribute; pos: number }[]} */ (
+            attrsMap.get(key)
+          );
 
-          // Build the candidate full list and test pairwise exclusivity.
-          const candidate = [...prevList, attr];
-          if (areInMutuallyExclusiveBranches(candidate, branchSegments)) {
+          // Build the candidate full list and test pairwise exclusivity,
+          // comparing positions rather than whole attribute ranges (see
+          // getComparable for why).
+          const candidate = [...prevList, { attr, pos }];
+          const nodesForCheck = candidate.map((c) => ({
+            range: /** @type {[number, number]} */ ([c.pos, c.pos]),
+          }));
+          if (areInMutuallyExclusiveBranches(nodesForCheck, branchSegments)) {
             // All pairs (including the new attr) are branch-exclusive: no
             // report, and add attr to the list to track further occurrences.
-            prevList.push(attr);
+            prevList.push({ attr, pos });
           } else {
             context.report({
               node: attr,
               data: {
-                attrName: attr.key.value,
+                attrName: displayName,
               },
               messageId: MESSAGE_IDS.DUPLICATE_ATTRS,
-              suggest: getSuggestions(attr),
+              suggest: getSuggestions(attr, displayName),
             });
             // Do NOT add to prevList: a confirmed duplicate should not
             // suppress future occurrences via the invariant.
           }
         } else {
-          attrsMap.set(key, [attr]);
+          attrsMap.set(key, [{ attr, pos }]);
         }
       });
     }

--- a/packages/eslint-plugin/lib/rules/no-duplicate-attrs.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-attrs.js
@@ -15,6 +15,10 @@ const { RULE_CATEGORY } = require("../constants");
 const { createVisitors } = require("./utils/visitors");
 const { getRuleUrl } = require("./utils/rule");
 const { hasTemplate } = require("./utils/node");
+const {
+  getBranchSegments,
+  areInMutuallyExclusiveBranches,
+} = require("./utils/branch-segments");
 
 const MESSAGE_IDS = {
   DUPLICATE_ATTRS: "duplicateAttrs",
@@ -45,6 +49,8 @@ module.exports = {
   },
 
   create(context) {
+    const branchSegments = getBranchSegments(context);
+
     /**
      * @param {Attribute} node
      * @returns {SuggestionReportDescriptor[]}
@@ -63,13 +69,46 @@ module.exports = {
 
     /** @param {Tag | StyleTag | ScriptTag} node */
     function check(node) {
-      if (Array.isArray(node.attributes)) {
-        const attrsSet = new Set();
-        node.attributes.forEach((attr) => {
-          if (hasTemplate(attr.key)) {
-            return;
-          }
-          if (attrsSet.has(attr.key.value.toLowerCase())) {
+      if (!Array.isArray(node.attributes)) return;
+
+      // Maps a normalised attribute key to the list of attribute nodes for
+      // that key that have NOT yet been reported as duplicates.
+      //
+      // Invariant: every pair of nodes in any list is mutually exclusive
+      // (they live in different branches of the same template if-block).
+      //
+      // When a new occurrence arrives we check it against the whole stored
+      // list.  If it is exclusive with ALL of them, the invariant still holds
+      // and we add it without reporting.  If it is NOT exclusive with at least
+      // one of them, it is a genuine runtime duplicate and we report it.
+      //
+      // This list-based approach correctly handles edge cases such as:
+      //
+      //   <span {%- if c1 -%}class="a"{%- else -%}class="b"{%- endif -%}
+      //         {%- if c1 -%}class="c"{%- endif -%}>
+      //
+      // where class[a] and class[c] (both in the same branch) are real
+      // duplicates even though class[a]/class[b] and class[b]/class[c] are
+      // individually exclusive.
+      /** @type {Map<string, Attribute[]>} */
+      const attrsMap = new Map();
+
+      node.attributes.forEach((attr) => {
+        if (hasTemplate(attr.key)) {
+          return;
+        }
+        const key = attr.key.value.toLowerCase();
+
+        if (attrsMap.has(key)) {
+          const prevList = /** @type {Attribute[]} */ (attrsMap.get(key));
+
+          // Build the candidate full list and test pairwise exclusivity.
+          const candidate = [...prevList, attr];
+          if (areInMutuallyExclusiveBranches(candidate, branchSegments)) {
+            // All pairs (including the new attr) are branch-exclusive: no
+            // report, and add attr to the list to track further occurrences.
+            prevList.push(attr);
+          } else {
             context.report({
               node: attr,
               data: {
@@ -78,12 +117,15 @@ module.exports = {
               messageId: MESSAGE_IDS.DUPLICATE_ATTRS,
               suggest: getSuggestions(attr),
             });
-          } else {
-            attrsSet.add(attr.key.value.toLowerCase());
+            // Do NOT add to prevList: a confirmed duplicate should not
+            // suppress future occurrences via the invariant.
           }
-        });
-      }
+        } else {
+          attrsMap.set(key, [attr]);
+        }
+      });
     }
+
     return createVisitors(context, {
       Tag: check,
       StyleTag: check,

--- a/packages/eslint-plugin/lib/rules/no-duplicate-id.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-id.js
@@ -46,7 +46,7 @@ module.exports = {
   create(context) {
     // Read branch segments once per file.  For non-HTML files (JS tagged
     // template literal paths) this will be [] and the check degrades
-    // gracefully to the original behaviour.
+    // gracefully to the original behavior.
     const branchSegments = getBranchSegments(context);
 
     const htmlIdAttrsMap = new Map();

--- a/packages/eslint-plugin/lib/rules/no-duplicate-id.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-id.js
@@ -15,6 +15,10 @@ const {
 } = require("./utils/settings");
 const { getSourceCode } = require("./utils/source-code");
 const { getRuleUrl } = require("./utils/rule");
+const {
+  getBranchSegments,
+  areInMutuallyExclusiveBranches,
+} = require("./utils/branch-segments");
 
 const MESSAGE_IDS = {
   DUPLICATE_ID: "duplicateId",
@@ -40,7 +44,13 @@ module.exports = {
   },
 
   create(context) {
+    // Read branch segments once per file.  For non-HTML files (JS tagged
+    // template literal paths) this will be [] and the check degrades
+    // gracefully to the original behaviour.
+    const branchSegments = getBranchSegments(context);
+
     const htmlIdAttrsMap = new Map();
+
     /** @param {Map<string, AttributeValue[]>} map */
     function createTagVisitor(map) {
       /** @param {Tag} node */
@@ -61,10 +71,19 @@ module.exports = {
       };
     }
 
-    /** @param {Map<string, AttributeValue[]>} map */
-    function report(map) {
+    /**
+     * @param {Map<string, AttributeValue[]>} map
+     * @param {typeof branchSegments} segments
+     */
+    function report(map, segments) {
       map.forEach((attrs) => {
         if (Array.isArray(attrs) && attrs.length > 1) {
+          // If every occurrence lives in a different branch of the same
+          // template if-block they are mutually exclusive at runtime — the
+          // same id can never appear twice in the rendered output.
+          if (areInMutuallyExclusiveBranches(attrs, segments)) {
+            return;
+          }
           attrs.forEach((attr) => {
             context.report({
               node: attr,
@@ -79,7 +98,7 @@ module.exports = {
     return {
       Tag: createTagVisitor(htmlIdAttrsMap),
       "Document:exit"() {
-        report(htmlIdAttrsMap);
+        report(htmlIdAttrsMap, branchSegments);
       },
       TaggedTemplateExpression(node) {
         const idAttrsMap = new Map();
@@ -88,7 +107,7 @@ module.exports = {
             Tag: createTagVisitor(idAttrsMap),
           });
         }
-        report(idAttrsMap);
+        report(idAttrsMap, branchSegments);
       },
       TemplateLiteral(node) {
         const idAttrsMap = new Map();
@@ -97,7 +116,7 @@ module.exports = {
             Tag: createTagVisitor(idAttrsMap),
           });
         }
-        report(idAttrsMap);
+        report(idAttrsMap, branchSegments);
       },
     };
   },

--- a/packages/eslint-plugin/lib/rules/no-duplicate-in-head.js
+++ b/packages/eslint-plugin/lib/rules/no-duplicate-in-head.js
@@ -12,6 +12,10 @@ const {
 } = require("./utils/settings");
 const { getSourceCode } = require("./utils/source-code");
 const { getRuleUrl } = require("./utils/rule");
+const {
+  getBranchSegments,
+  areInMutuallyExclusiveBranches,
+} = require("./utils/branch-segments");
 
 const MESSAGE_IDS = {
   DUPLICATE_TAG: "duplicateTag",
@@ -72,6 +76,8 @@ module.exports = {
   },
 
   create(context) {
+    const branchSegments = getBranchSegments(context);
+
     const htmlTagsMap = new Map();
     let headCount = 0;
 
@@ -124,10 +130,16 @@ module.exports = {
       };
     }
 
-    /** @param {Map<string, Tag[]>} map */
-    function report(map) {
+    /**
+     * @param {Map<string, Tag[]>} map
+     * @param {typeof branchSegments} segments
+     */
+    function report(map, segments) {
       map.forEach((tags, tagKey) => {
         if (Array.isArray(tags) && tags.length > 1) {
+          if (areInMutuallyExclusiveBranches(tags, segments)) {
+            return;
+          }
           tags.slice(1).forEach((tag) => {
             context.report({
               node: tag,
@@ -146,7 +158,7 @@ module.exports = {
       "Tag:exit": htmlVisitor["Tag:exit"],
 
       "Document:exit"() {
-        report(htmlTagsMap);
+        report(htmlTagsMap, branchSegments);
       },
 
       TaggedTemplateExpression(node) {
@@ -156,7 +168,7 @@ module.exports = {
         if (shouldCheckTaggedTemplateExpression(node, context)) {
           const visitor = createTagVisitor(tagsMap, headCountRef);
           parseTemplateLiteral(node.quasi, getSourceCode(context), visitor);
-          report(tagsMap);
+          report(tagsMap, branchSegments);
         }
       },
 
@@ -167,7 +179,7 @@ module.exports = {
         if (shouldCheckTemplateLiteral(node, context)) {
           const visitor = createTagVisitor(tagsMap, headCountRef);
           parseTemplateLiteral(node, getSourceCode(context), visitor);
-          report(tagsMap);
+          report(tagsMap, branchSegments);
         }
       },
     };

--- a/packages/eslint-plugin/lib/rules/utils/branch-segments.js
+++ b/packages/eslint-plugin/lib/rules/utils/branch-segments.js
@@ -1,0 +1,98 @@
+/**
+ * Rule-side helpers for branch-based duplicate suppression.
+ *
+ * The parser attaches a `branchSegments` array to the root Program node
+ * during its branch-annotation pass (see packages/parser/lib/branch-annotation.js
+ * and packages/parser/lib/parser.js).
+ *
+ * Each segment is:
+ *   { groupId: number; branchIndex: number; start: number; end: number }
+ *
+ * All segments that share the same `groupId` belong to one {% if %} block.
+ * `branchIndex` is 0 for the if-body, 1 for the first elseif/else, etc.
+ * `start` / `end` are character offsets into the original source (same
+ * coordinate space as AST node `range` values).
+ *
+ * A set of nodes is "mutually exclusive" when, for every pair (A, B), there
+ * exists at least one if-block group where both A and B fall inside it but in
+ * *different* branches.  When every pair is exclusive the nodes can never all
+ * be present in the rendered output simultaneously, so "duplicate" rules
+ * should suppress their report.
+ */
+
+const { getSourceCode } = require("./source-code");
+
+/**
+ * Retrieve the pre-computed branch segments from the AST root.
+ * Returns an empty array for non-HTML files or files parsed without a
+ * template engine syntax configuration.
+ *
+ * @param {import("eslint").Rule.RuleContext} context
+ * @returns {Array<{ groupId: number; branchIndex: number; start: number; end: number }>}
+ */
+function getBranchSegments(context) {
+  const ast = getSourceCode(context).ast;
+  return (ast && ast.branchSegments) || [];
+}
+
+/**
+ * Return true when every pair of nodes in `nodes` is located in different
+ * branches of the same template if-block, meaning they can never all be
+ * present in the rendered output at the same time.
+ *
+ * Each element of `nodes` must have a `.range` property ([start, end]).
+ *
+ * @param {Array<{ range: [number, number] }>} nodes
+ * @param {Array<{ groupId: number; branchIndex: number; start: number; end: number }>} branchSegments
+ * @returns {boolean}
+ */
+function areInMutuallyExclusiveBranches(nodes, branchSegments) {
+  if (nodes.length <= 1) return false;
+  if (!branchSegments || branchSegments.length === 0) return false;
+
+  // Group segments by their if-block groupId so we can query one block at a time.
+  /** @type {Map<number, typeof branchSegments>} */
+  const groups = new Map();
+  for (const seg of branchSegments) {
+    let list = groups.get(seg.groupId);
+    if (!list) {
+      list = [];
+      groups.set(seg.groupId, list);
+    }
+    list.push(seg);
+  }
+
+  // For every pair (i, j), verify that at least one if-block group places
+  // the two nodes in different branches.  If any pair has no such group, the
+  // nodes are NOT all mutually exclusive and we must not suppress the report.
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const posA = nodes[i].range[0];
+      const posB = nodes[j].range[0];
+      let foundExclusiveGroup = false;
+
+      for (const segments of groups.values()) {
+        let branchA = -1;
+        let branchB = -1;
+        for (const seg of segments) {
+          if (posA >= seg.start && posA < seg.end) branchA = seg.branchIndex;
+          if (posB >= seg.start && posB < seg.end) branchB = seg.branchIndex;
+        }
+        // Both nodes must be *inside* this group's branches, but in different ones.
+        if (branchA !== -1 && branchB !== -1 && branchA !== branchB) {
+          foundExclusiveGroup = true;
+          break;
+        }
+      }
+
+      if (!foundExclusiveGroup) return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = {
+  getBranchSegments,
+  areInMutuallyExclusiveBranches,
+};

--- a/packages/eslint-plugin/lib/rules/utils/branch-segments.js
+++ b/packages/eslint-plugin/lib/rules/utils/branch-segments.js
@@ -37,7 +37,7 @@ const { getSourceCode } = require("./source-code");
  * @returns {Array<{ groupId: number; branchIndex: number; start: number; end: number }>}
  */
 function getBranchSegments(context) {
-  const ast = /** @type {any} */ (getSourceCode(context).ast);
+  const { ast } = /** @type {{ ast: any }} */ (getSourceCode(context));
   return (ast && ast.branchSegments) || [];
 }
 

--- a/packages/eslint-plugin/lib/rules/utils/branch-segments.js
+++ b/packages/eslint-plugin/lib/rules/utils/branch-segments.js
@@ -47,6 +47,37 @@ function getBranchSegments(context) {
 }
 
 /**
+ * Retrieve the pre-computed branch-control token ranges from the AST root. Each
+ * range is the [start, end] span of a template token that was classified as a
+ * branch-control token (an `{% if %}`, `{% else %}`, `{% endif %}`, or similar
+ * structural marker) as opposed to a plain value-interpolation token (e.g. `{{
+ * name }}`).
+ *
+ * Rules use this to safely strip a branch-control token that ends up glued onto
+ * the text of a following node (e.g. an attribute key) with no separating
+ * whitespace, while continuing to treat a glued _interpolation_ token
+ * conservatively (the name is genuinely dynamic and can't be compared).
+ *
+ * @param {Context<any[]>} context
+ * @returns {[number, number][]}
+ */
+function getControlTokenRanges(context) {
+  const { ast } = /** @type {{ ast: any }} */ (getSourceCode(context));
+  return (ast && ast.branchControlRanges) || [];
+}
+
+/**
+ * @param {[number, number]} range
+ * @param {[number, number][]} controlTokenRanges
+ * @returns {boolean}
+ */
+function isControlToken(range, controlTokenRanges) {
+  return controlTokenRanges.some(
+    ([start, end]) => start === range[0] && end === range[1]
+  );
+}
+
+/**
  * Return true when every pair of nodes in `nodes` is located in different
  * branches of the same template if-block, meaning they can never all be present
  * in the rendered output at the same time.
@@ -110,5 +141,7 @@ function areInMutuallyExclusiveBranches(nodes, branchSegments) {
 
 module.exports = {
   getBranchSegments,
+  getControlTokenRanges,
+  isControlToken,
   areInMutuallyExclusiveBranches,
 };

--- a/packages/eslint-plugin/lib/rules/utils/branch-segments.js
+++ b/packages/eslint-plugin/lib/rules/utils/branch-segments.js
@@ -20,6 +20,8 @@
  * should suppress their report.
  */
 
+/** @import {Context} from "../../types" */
+
 const { getSourceCode } = require("./source-code");
 
 /**
@@ -27,11 +29,15 @@ const { getSourceCode } = require("./source-code");
  * Returns an empty array for non-HTML files or files parsed without a
  * template engine syntax configuration.
  *
- * @param {import("eslint").Rule.RuleContext} context
+ * `branchSegments` is attached dynamically to the Program node by
+ * packages/parser/lib/parser.js and is not part of the standard typed
+ * Program definition, so ast is cast to `any` to access it.
+ *
+ * @param {Context<any[]>} context
  * @returns {Array<{ groupId: number; branchIndex: number; start: number; end: number }>}
  */
 function getBranchSegments(context) {
-  const ast = getSourceCode(context).ast;
+  const ast = /** @type {any} */ (getSourceCode(context).ast);
   return (ast && ast.branchSegments) || [];
 }
 

--- a/packages/eslint-plugin/lib/rules/utils/branch-segments.js
+++ b/packages/eslint-plugin/lib/rules/utils/branch-segments.js
@@ -1,23 +1,23 @@
 /**
  * Rule-side helpers for branch-based duplicate suppression.
  *
- * The parser attaches a `branchSegments` array to the root Program node
- * during its branch-annotation pass (see packages/parser/lib/branch-annotation.js
- * and packages/parser/lib/parser.js).
+ * The parser attaches a `branchSegments` array to the root Program node during
+ * its branch-annotation pass (see packages/parser/lib/branch-annotation.js and
+ * packages/parser/lib/parser.js).
  *
- * Each segment is:
- *   { groupId: number; branchIndex: number; start: number; end: number }
+ * Each segment is: { groupId: number; branchIndex: number; start: number; end:
+ * number }
  *
  * All segments that share the same `groupId` belong to one {% if %} block.
- * `branchIndex` is 0 for the if-body, 1 for the first elseif/else, etc.
- * `start` / `end` are character offsets into the original source (same
- * coordinate space as AST node `range` values).
+ * `branchIndex` is 0 for the if-body, 1 for the first elseif/else, etc. `start`
+ * / `end` are character offsets into the original source (same coordinate space
+ * as AST node `range` values).
  *
  * A set of nodes is "mutually exclusive" when, for every pair (A, B), there
  * exists at least one if-block group where both A and B fall inside it but in
- * *different* branches.  When every pair is exclusive the nodes can never all
- * be present in the rendered output simultaneously, so "duplicate" rules
- * should suppress their report.
+ * _different_ branches. When every pair is exclusive the nodes can never all be
+ * present in the rendered output simultaneously, so "duplicate" rules should
+ * suppress their report.
  */
 
 /** @import {Context} from "../../types" */
@@ -25,16 +25,21 @@
 const { getSourceCode } = require("./source-code");
 
 /**
- * Retrieve the pre-computed branch segments from the AST root.
- * Returns an empty array for non-HTML files or files parsed without a
- * template engine syntax configuration.
+ * Retrieve the pre-computed branch segments from the AST root. Returns an empty
+ * array for non-HTML files or files parsed without a template engine syntax
+ * configuration.
  *
  * `branchSegments` is attached dynamically to the Program node by
- * packages/parser/lib/parser.js and is not part of the standard typed
- * Program definition, so ast is cast to `any` to access it.
+ * packages/parser/lib/parser.js and is not part of the standard typed Program
+ * definition, so ast is cast to `any` to access it.
  *
  * @param {Context<any[]>} context
- * @returns {Array<{ groupId: number; branchIndex: number; start: number; end: number }>}
+ * @returns {{
+ *   groupId: number;
+ *   branchIndex: number;
+ *   start: number;
+ *   end: number;
+ * }[]}
  */
 function getBranchSegments(context) {
   const { ast } = /** @type {{ ast: any }} */ (getSourceCode(context));
@@ -43,13 +48,18 @@ function getBranchSegments(context) {
 
 /**
  * Return true when every pair of nodes in `nodes` is located in different
- * branches of the same template if-block, meaning they can never all be
- * present in the rendered output at the same time.
+ * branches of the same template if-block, meaning they can never all be present
+ * in the rendered output at the same time.
  *
  * Each element of `nodes` must have a `.range` property ([start, end]).
  *
- * @param {Array<{ range: [number, number] }>} nodes
- * @param {Array<{ groupId: number; branchIndex: number; start: number; end: number }>} branchSegments
+ * @param {{ range: [number, number] }[]} nodes
+ * @param {{
+ *   groupId: number;
+ *   branchIndex: number;
+ *   start: number;
+ *   end: number;
+ * }[]} branchSegments
  * @returns {boolean}
  */
 function areInMutuallyExclusiveBranches(nodes, branchSegments) {

--- a/packages/eslint-plugin/tests/e2e/index.test.js
+++ b/packages/eslint-plugin/tests/e2e/index.test.js
@@ -38,7 +38,10 @@ for (const testDir of testDirs) {
       // @ts-ignore
       const result = linter.verifyAndFix(source, config);
       messages = result.messages;
-      expect(result.output).toEqual(expected);
+      // Replace `\r\n` with `\n` to prevent failure of the test when testing on Windows
+      expect(result.output.replace(/\r\n/g, "\n")).toEqual(
+        expected.replace(/\r\n/g, "\n")
+      );
     } else {
       // If no `fixed.html`, assume the `source.html` should have no errors/warnings
       // @ts-ignore

--- a/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
@@ -47,8 +47,14 @@ ruleTester.run("no-duplicate-attrs", rule, {
     },
     // The same attribute name in different Twig if/else branches on the same
     // tag is not a real duplicate — only one branch renders at runtime.
+    // Twig doesn't require whitespace after a block tag (e.g. {%if cond%} is
+    // valid, identical to {% if cond %}), and this is verified to work
+    // without it: es-html-parser glues the token's literal text onto the
+    // following attribute key when there's no separating space, but the
+    // rule reconstructs the real attribute name from `key.parts` rather than
+    // relying on `key.value`, so spacing makes no difference to detection.
     {
-      code: `<span {% if cond %}class="active"{% else %}class="inactive"{% endif %}>text</span>`,
+      code: `<span {%if cond%}class="active"{%else%}class="inactive"{%endif%}>text</span>`,
       languageOptions: {
         parserOptions: {
           templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
@@ -57,18 +63,7 @@ ruleTester.run("no-duplicate-attrs", rule, {
     },
     // Three branches: still mutually exclusive.
     {
-      code: `<a {% if lang == "en" %}lang="en"{% elseif lang == "fi" %}lang="fi"{% else %}lang="sv"{% endif %} href="/">home</a>`,
-      languageOptions: {
-        parserOptions: {
-          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
-        },
-      },
-    },
-    // Three occurrences of 'class' across mutually exclusive branches —
-    // all pairs are branch-exclusive, so no error should be reported.
-    {
-      code: `<span {% if c1 %}class="a"{% else %}class="b"{% endif %}
-        {% if c1 %}class="c"{% endif %}>text</span>`,
+      code: `<a {%if lang=="en"%}lang="en"{%elseif lang=="fi"%}lang="fi"{%else%}lang="sv"{%endif%} href="/">home</a>`,
       languageOptions: {
         parserOptions: {
           templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
@@ -76,25 +71,35 @@ ruleTester.run("no-duplicate-attrs", rule, {
       },
     },
     // Two separate attributes, each with their own if/else branches.
-    // Each attribute's second branch triggers the push path.
+    // Each attribute's second branch triggers the prevList.push(attr) path.
     {
-      code: `<div {% if x %}data-id="1"{% else %}data-id="2"{% endif %}
-           {% if y %}aria-label="x"{% else %}aria-label="y"{% endif %}>`,
+      code: `<div {%if x%}data-id="1"{%else%}data-id="2"{%endif%} {%if y%}aria-label="x"{%else%}aria-label="y"{%endif%}>`,
       languageOptions: {
         parserOptions: {
           templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
         },
       },
     },
-    // HANDLEBAR_EXTENDED: the parser sees both class attributes inside
-    // {{...}} template tokens (confirmed by the existing aria-label test),
-    // and branch checking suppresses the duplicate.  This specifically
-    // exercises the prevList.push(attr) path in the check() function.
+    // HANDLEBAR_EXTENDED: same if/else suppression via {{#if}}/{{else}}/{{/if}}.
     {
       code: `<span {{#if cond}}class="a"{{else}}class="b"{{/if}}>text</span>`,
       languageOptions: {
         parserOptions: {
           templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.HANDLEBAR_EXTENDED,
+        },
+      },
+    },
+    // A key with a genuinely dynamic embedded interpolation (not a
+    // branch-control token) must remain conservatively skipped rather than
+    // compared — its real name can't be known statically, so it must never
+    // be treated as either a suppressible or a reportable duplicate.
+    {
+      code: `<div data-{{a}}="1" data-{{b}}="2">text</div>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: {
+            "{{": "}}",
+          },
         },
       },
     },
@@ -270,6 +275,33 @@ ruleTester.run("no-duplicate-attrs", rule, {
               messageId: "removeAttr",
               data: { attrName: "class" },
               output: `<div class="a" >text</div>`,
+            },
+          ],
+        },
+      ],
+    },
+    // Same attribute key in two SEPARATE if-blocks (not one if/else) can
+    // both render simultaneously (e.g. both conditions true), so this is a
+    // genuine duplicate and must still be reported even with a branch-aware
+    // engine configured — regardless of Twig's optional whitespace after
+    // block tags. areInMutuallyExclusiveBranches correctly returns false for
+    // this pair since they belong to different if-block groups (verified
+    // against the real parser).
+    {
+      code: `<div {%if c1%}class="a"{%endif%}{%if c2%}class="b"{%endif%}>text</div>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+      errors: [
+        {
+          message: "The attribute 'class' is duplicated.",
+          suggestions: [
+            {
+              messageId: "removeAttr",
+              data: { attrName: "class" },
+              output: `<div {%if c1%}class="a"{%endif%}>text</div>`,
             },
           ],
         },

--- a/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
@@ -1,5 +1,6 @@
 const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-duplicate-attrs");
+const { TEMPLATE_ENGINE_SYNTAX } = require("@html-eslint/parser");
 
 const ruleTester = createRuleTester();
 const templateRuleTester = createRuleTester("espree");
@@ -41,6 +42,25 @@ ruleTester.run("no-duplicate-attrs", rule, {
           templateEngineSyntax: {
             "{{": "}}",
           },
+        },
+      },
+    },
+    // The same attribute name in different Twig if/else branches on the same
+    // tag is not a real duplicate — only one branch renders at runtime.
+    {
+      code: `<span {% if cond %}class="active"{% else %}class="inactive"{% endif %}>text</span>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+    },
+    // Three branches: still mutually exclusive.
+    {
+      code: `<a {% if lang == "en" %}lang="en"{% elseif lang == "fi" %}lang="fi"{% else %}lang="sv"{% endif %} href="/">home</a>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
         },
       },
     },
@@ -174,6 +194,21 @@ ruleTester.run("no-duplicate-attrs", rule, {
               output: `<div foo  {{aa}} {{aa}}> </div>`,
             },
           ],
+        },
+      ],
+    },
+    // Attributes in two separate Twig if-blocks (not one if/else) can both
+    // render at the same time and must still be reported.
+    {
+      code: `<span {% if c1 %}class="a"{% endif %} {% if c2 %}class="b"{% endif %}>text</span>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+      errors: [
+        {
+          message: "The attribute 'class' is duplicated.",
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
@@ -86,6 +86,18 @@ ruleTester.run("no-duplicate-attrs", rule, {
         },
       },
     },
+    // HANDLEBAR_EXTENDED: the parser sees both class attributes inside
+    // {{...}} template tokens (confirmed by the existing aria-label test),
+    // and branch checking suppresses the duplicate.  This specifically
+    // exercises the prevList.push(attr) path in the check() function.
+    {
+      code: `<span {{#if cond}}class="a"{{else}}class="b"{{/if}}>text</span>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.HANDLEBAR_EXTENDED,
+        },
+      },
+    },
   ],
   invalid: [
     {
@@ -214,6 +226,50 @@ ruleTester.run("no-duplicate-attrs", rule, {
                 attrName: "foo",
               },
               output: `<div foo  {{aa}} {{aa}}> </div>`,
+            },
+          ],
+        },
+      ],
+    },
+    // Genuine duplicate with TWIG configured — no template blocks in the
+    // source so branchSegments is empty; the error fires normally.
+    {
+      code: `<div class="a" class="b">text</div>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+      errors: [
+        {
+          message: "The attribute 'class' is duplicated.",
+          suggestions: [
+            {
+              messageId: "removeAttr",
+              data: { attrName: "class" },
+              output: `<div class="a" >text</div>`,
+            },
+          ],
+        },
+      ],
+    },
+    // Genuine duplicate with HANDLEBAR_EXTENDED configured — both attributes
+    // are plain HTML (no template blocks), so not exclusive; error fires.
+    {
+      code: `<div class="a" class="b">text</div>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.HANDLEBAR_EXTENDED,
+        },
+      },
+      errors: [
+        {
+          message: "The attribute 'class' is duplicated.",
+          suggestions: [
+            {
+              messageId: "removeAttr",
+              data: { attrName: "class" },
+              output: `<div class="a" >text</div>`,
             },
           ],
         },

--- a/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
@@ -64,6 +64,28 @@ ruleTester.run("no-duplicate-attrs", rule, {
         },
       },
     },
+    // Three occurrences of 'class' across mutually exclusive branches —
+    // all pairs are branch-exclusive, so no error should be reported.
+    {
+      code: `<span {% if c1 %}class="a"{% else %}class="b"{% endif %}
+        {% if c1 %}class="c"{% endif %}>text</span>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+    },
+    // Two separate attributes, each with their own if/else branches.
+    // Each attribute's second branch triggers the push path.
+    {
+      code: `<div {% if x %}data-id="1"{% else %}data-id="2"{% endif %}
+           {% if y %}aria-label="x"{% else %}aria-label="y"{% endif %}>`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-attrs.test.js
@@ -197,21 +197,6 @@ ruleTester.run("no-duplicate-attrs", rule, {
         },
       ],
     },
-    // Attributes in two separate Twig if-blocks (not one if/else) can both
-    // render at the same time and must still be reported.
-    {
-      code: `<span {% if c1 %}class="a"{% endif %} {% if c2 %}class="b"{% endif %}>text</span>`,
-      languageOptions: {
-        parserOptions: {
-          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
-        },
-      },
-      errors: [
-        {
-          message: "The attribute 'class' is duplicated.",
-        },
-      ],
-    },
   ],
 });
 

--- a/packages/eslint-plugin/tests/rules/no-duplicate-id.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-id.test.js
@@ -1,5 +1,6 @@
 const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-duplicate-id");
+const { TEMPLATE_ENGINE_SYNTAX } = require("@html-eslint/parser");
 
 const ruleTester = createRuleTester();
 const templateRuleTester = createRuleTester("espree");
@@ -15,6 +16,44 @@ ruleTester.run("no-duplicate-id", rule, {
 </body>
 </html>
 `,
+    },
+    // Duplicates in mutually exclusive Twig if/else branches are not errors.
+    {
+      code: `
+<p>
+  {% if result %}
+    <span id="status">yes</span>
+  {% else %}
+    <span id="status">no</span>
+  {% endif %}
+</p>
+`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+    },
+    // Dmitrii's original use case: four spans in four branches.
+    {
+      code: `
+<p>
+  {% if check_result is same as(null) %}
+    <span id="acc_check_result"></span>
+  {% elseif check_result is same as(false) %}
+    <span id="acc_check_result" class="failure">Invalid</span>
+  {% elseif check_result is same as(true) %}
+    <span id="acc_check_result" class="success">Valid</span>
+  {% else %}
+    <span id="acc_check_result" class="failure">Wrong key</span>
+  {% endif %}
+</p>
+`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
     },
   ],
   invalid: [
@@ -56,6 +95,20 @@ ruleTester.run("no-duplicate-id", rule, {
           line: 5,
         },
       ],
+    },
+    // Duplicates in two SEPARATE if-blocks can both render simultaneously
+    // and must still be reported.
+    {
+      code: `
+{% if c1 %}<div id="foo"></div>{% endif %}
+{% if c2 %}<div id="foo"></div>{% endif %}
+`,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+      errors: [{ messageId: "duplicateId" }, { messageId: "duplicateId" }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-duplicate-id.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-id.test.js
@@ -34,7 +34,7 @@ ruleTester.run("no-duplicate-id", rule, {
         },
       },
     },
-    // Dmitrii's original use case: four spans in four branches.
+    // Original use case: four spans in four branches.
     {
       code: `
 <p>

--- a/packages/eslint-plugin/tests/rules/no-duplicate-in-head.test.js
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-in-head.test.js
@@ -1,5 +1,6 @@
 const createRuleTester = require("../rule-tester");
 const rule = require("../../lib/rules/no-duplicate-in-head");
+const { TEMPLATE_ENGINE_SYNTAX } = require("@html-eslint/parser");
 
 const ruleTester = createRuleTester();
 const templateRuleTester = createRuleTester("espree");
@@ -37,6 +38,47 @@ ruleTester.run("no-duplicate-in-head", rule, {
           </head>
         </html>
       `,
+    },
+    // Duplicate head tags in mutually exclusive Twig if/else branches are
+    // not errors — only one branch's tag appears in the rendered output.
+    {
+      code: `
+        <html>
+          <head>
+            {% if lang == "en" %}
+              <title>English Page</title>
+            {% else %}
+              <title>Other Language Page</title>
+            {% endif %}
+          </head>
+        </html>
+      `,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+    },
+    // Multiple head tag types, each duplicated across branches.
+    {
+      code: `
+        <html>
+          <head>
+            {% if canonical %}
+              <link rel="canonical" href="https://example.com/a">
+              <meta name="viewport" content="width=device-width">
+            {% else %}
+              <link rel="canonical" href="https://example.com/b">
+              <meta name="viewport" content="width=device-width, initial-scale=1">
+            {% endif %}
+          </head>
+        </html>
+      `,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
     },
   ],
   invalid: [
@@ -117,6 +159,33 @@ ruleTester.run("no-duplicate-in-head", rule, {
         {
           messageId: "duplicateTag",
           data: { tag: "base" },
+        },
+      ],
+    },
+    // Duplicate head tags in two SEPARATE if-blocks (not one if/else) can
+    // both render simultaneously and must still be reported.
+    {
+      code: `
+        <html>
+          <head>
+            {% if cond %}
+              <title>First</title>
+            {% endif %}
+            {% if other %}
+              <title>Second</title>
+            {% endif %}
+          </head>
+        </html>
+      `,
+      languageOptions: {
+        parserOptions: {
+          templateEngineSyntax: TEMPLATE_ENGINE_SYNTAX.TWIG,
+        },
+      },
+      errors: [
+        {
+          messageId: "duplicateTag",
+          data: { tag: "title" },
         },
       ],
     },

--- a/packages/parser/lib/branch-annotation.js
+++ b/packages/parser/lib/branch-annotation.js
@@ -37,18 +37,10 @@ function matches(pattern, content) {
 }
 
 /**
- * Compute branch segments from a list of template token ranges.
+ * Classify every template token that belongs to a branch-aware delimiter.
  *
- * @param {TemplateSyntax[]} templateInfos The TemplateSyntax[] returned by
- *   `@html-eslint/template-syntax-parser`. Each entry covers one complete
- *   template token: open is the [start,end] of the opening delimiter, close is
- *   the [start,end] of the closing delimiter. Content lives between open[1] and
- *   close[0].
- * @param {string} source The source text that templateInfos was parsed from.
- *   Must be the same string (same character offsets) — i.e. the
- *   frontmatter-stripped `html` string from getOptions(), NOT the full `code`
- *   string. The caller is responsible for adding any frontmatter offset to the
- *   returned segments.
+ * @param {TemplateSyntax[]} templateInfos
+ * @param {string} source
  * @param {{
  *   open: string;
  *   close: string;
@@ -60,12 +52,13 @@ function matches(pattern, content) {
  *     blockClose?: RegExp | string;
  *   };
  * }[]} syntaxItems
- *   Normalized SyntaxConfigItem array. Only items that have a .branch property
- *   are consulted; the rest are ignored.
- * @returns {BranchSegment[]}
+ * @returns {{
+ *   role: "START" | "CONTINUE" | "END" | "BLOCK_OPEN" | "BLOCK_CLOSE";
+ *   tokenStart: number;
+ *   tokenEnd: number;
+ * }[]}
  */
-function computeBranchSegments(templateInfos, source, syntaxItems) {
-  // Fast exit: nothing to do without branch-aware items.
+function classifyTemplateTokens(templateInfos, source, syntaxItems) {
   /** @type {Map<string, (typeof syntaxItems)[number]>} */
   const itemByOpen = new Map();
   for (const item of syntaxItems) {
@@ -74,8 +67,6 @@ function computeBranchSegments(templateInfos, source, syntaxItems) {
     }
   }
   if (itemByOpen.size === 0) return [];
-
-  // --- 1. Classify every token that belongs to a branch-aware delimiter. ---
 
   /**
    * @type {{
@@ -128,12 +119,44 @@ function computeBranchSegments(templateInfos, source, syntaxItems) {
     }
   }
 
-  if (classified.length === 0) return [];
-
   // template-syntax-parser emits tokens in source order, but sort defensively.
   classified.sort((a, b) => a.tokenStart - b.tokenStart);
+  return classified;
+}
 
-  // --- 2. Stack-based pass to build BranchSegments. ---
+/**
+ * Compute branch segments from a list of template token ranges.
+ *
+ * @param {TemplateSyntax[]} templateInfos The TemplateSyntax[] returned by
+ * @param {string} source The source text that templateInfos was parsed from.
+ *   Must be the same string (same character offsets) — i.e. the
+ *   frontmatter-stripped `html` string from getOptions(), NOT the full `code`
+ *   string. The caller is responsible for adding any frontmatter offset to the
+ *   returned segments.
+ * @param {{
+ *   open: string;
+ *   close: string;
+ *   branch?: {
+ *     start: RegExp;
+ *     continue: RegExp;
+ *     end: RegExp;
+ *     blockOpen?: RegExp;
+ *     blockClose?: RegExp;
+ *   };
+ * }[]} syntaxItems
+ *   Normalized SyntaxConfigItem array. Only items that have a .branch property
+ *   are consulted; the rest are ignored.
+ * @returns {BranchSegment[]}
+ * @html-eslint/template-syntax-parser. Each entry covers one complete
+ *   template token: open is the [start,end] of the opening delimiter, close is
+ *   the [start,end] of the closing delimiter. Content lives between open[1] and
+ *   close[0].
+ */
+function computeBranchSegments(templateInfos, source, syntaxItems) {
+  const classified = classifyTemplateTokens(templateInfos, source, syntaxItems);
+  if (classified.length === 0) return [];
+
+  // --- Stack-based pass to build BranchSegments. ---
   //
   // Stack entries are one of two shapes:
   //   { type: 'if',    groupId, branchIndex, segmentStart }
@@ -216,6 +239,44 @@ function computeBranchSegments(templateInfos, source, syntaxItems) {
   return segments;
 }
 
+/**
+ * Return the [start, end] ranges of every template token that was classified as
+ * a branch-control token (START / CONTINUE / END / BLOCK_OPEN / BLOCK_CLOSE) —
+ * i.e. an `{% if %}`, `{% else %}`, `{% endif %}`, or similar structural token,
+ * as opposed to a plain value-interpolation token like `{{ name }}`.
+ *
+ * Rules use this to distinguish two situations where a template token ends up
+ * glued onto the text of a following attribute key (because there is no
+ * whitespace separating them, e.g. `{%if x%}data-id="1"`):
+ *
+ * 1. The glued token is a branch-control token — the attribute's real name
+ *    ("data-id") is statically known and can be safely compared across branches
+ *    once the glued prefix is stripped.
+ * 2. The glued token is a plain interpolation — the attribute's name is genuinely
+ *    dynamic (e.g. `data-{{name}}`) and can't be safely compared at all, so it
+ *    must continue to be skipped.
+ *
+ * @param {TemplateSyntax[]} templateInfos
+ * @param {string} source
+ * @param {{
+ *   open: string;
+ *   close: string;
+ *   branch?: {
+ *     start: RegExp | string;
+ *     continue: RegExp | string;
+ *     end: RegExp | string;
+ *     blockOpen?: RegExp | string;
+ *     blockClose?: RegExp | string;
+ *   };
+ * }[]} syntaxItems
+ * @returns {[number, number][]}
+ */
+function getControlTokenRanges(templateInfos, source, syntaxItems) {
+  const classified = classifyTemplateTokens(templateInfos, source, syntaxItems);
+  return classified.map((t) => [t.tokenStart, t.tokenEnd]);
+}
+
 module.exports = {
   computeBranchSegments,
+  getControlTokenRanges,
 };

--- a/packages/parser/lib/branch-annotation.js
+++ b/packages/parser/lib/branch-annotation.js
@@ -1,0 +1,196 @@
+/**
+ * Branch annotation for @html-eslint/parser.
+ *
+ * @html-eslint/template-syntax-parser already records every template token as
+ * an opaque {open, close} range pair.  This module classifies those tokens
+ * (using per-engine patterns stored in the SyntaxConfigItem.branch property)
+ * and emits a flat list of BranchSegment objects.
+ *
+ * A BranchSegment represents one branch body of one {% if %} block:
+ *   groupId      — same for all branches of the same if-block
+ *   branchIndex  — 0 for the if-body, 1 for first elseif/else, etc.
+ *   start / end  — source character range of the branch content (exclusive of
+ *                  the template tokens themselves)
+ *
+ * Rules can use these segments to decide whether two "duplicate" nodes are
+ * actually unreachable simultaneously, because every path through the template
+ * can only enter one branch of any given if-block.
+ *
+ * @typedef {{ groupId: number; branchIndex: number; start: number; end: number }} BranchSegment
+ */
+
+/**
+ * @param {RegExp | string | undefined} pattern
+ * @param {string} content
+ * @returns {boolean}
+ */
+function matches(pattern, content) {
+  if (!pattern) return false;
+  if (pattern instanceof RegExp) return pattern.test(content);
+  return content.indexOf(pattern) !== -1;
+}
+
+/**
+ * Compute branch segments from a list of template token ranges.
+ *
+ * @param {Array<{ open: [number,number]; close: [number,number] }>} templateInfos
+ *   The TemplateSyntax[] returned by @html-eslint/template-syntax-parser.
+ *   Each entry covers one complete template token: open is the [start,end]
+ *   of the opening delimiter, close is the [start,end] of the closing
+ *   delimiter.  Content lives between open[1] and close[0].
+ *
+ * @param {string} source
+ *   The source text that templateInfos was parsed from.  Must be the same
+ *   string (same character offsets) — i.e. the frontmatter-stripped `html`
+ *   string from getOptions(), NOT the full `code` string.  The caller is
+ *   responsible for adding any frontmatter offset to the returned segments.
+ *
+ * @param {Array<{ open: string; close: string; branch?: {
+ *   start:      RegExp;
+ *   continue:   RegExp;
+ *   end:        RegExp;
+ *   blockOpen?:  RegExp;
+ *   blockClose?: RegExp;
+ * } }>} syntaxItems
+ *   Normalized SyntaxConfigItem array.  Only items that have a .branch
+ *   property are consulted; the rest are ignored.
+ *
+ * @returns {BranchSegment[]}
+ */
+function computeBranchSegments(templateInfos, source, syntaxItems) {
+  // Fast exit: nothing to do without branch-aware items.
+  /** @type {Map<string, typeof syntaxItems[number]>} */
+  const itemByOpen = new Map();
+  for (const item of syntaxItems) {
+    if (item.branch) {
+      itemByOpen.set(item.open, item);
+    }
+  }
+  if (itemByOpen.size === 0) return [];
+
+  // --- 1. Classify every token that belongs to a branch-aware delimiter. ---
+
+  /**
+   * @type {Array<{
+   *   role: 'START'|'CONTINUE'|'END'|'BLOCK_OPEN'|'BLOCK_CLOSE';
+   *   tokenStart: number;
+   *   tokenEnd: number;
+   * }>}
+   */
+  const classified = [];
+
+  for (const info of templateInfos) {
+    const openDelim = source.slice(info.open[0], info.open[1]);
+    const item = itemByOpen.get(openDelim);
+    if (!item || !item.branch) continue;
+
+    // Content between the opening and closing delimiters, e.g. " if cond ".
+    const content = source.slice(info.open[1], info.close[0]);
+    const b = item.branch;
+
+    let role = null;
+    // Order matters: END before CONTINUE so that patterns like
+    // /^\s*-?\s*(elseif|else)\b/ don't accidentally match "endif" (they won't
+    // with these specific patterns, but being explicit is safer).
+    if (matches(b.start, content)) {
+      role = "START";
+    } else if (matches(b.end, content)) {
+      role = "END";
+    } else if (matches(b.continue, content)) {
+      role = "CONTINUE";
+    } else if (b.blockOpen && matches(b.blockOpen, content)) {
+      role = "BLOCK_OPEN";
+    } else if (b.blockClose && matches(b.blockClose, content)) {
+      role = "BLOCK_CLOSE";
+    }
+
+    if (role) {
+      classified.push({
+        role,
+        tokenStart: info.open[0],
+        tokenEnd: info.close[1],
+      });
+    }
+  }
+
+  if (classified.length === 0) return [];
+
+  // template-syntax-parser emits tokens in source order, but sort defensively.
+  classified.sort((a, b) => a.tokenStart - b.tokenStart);
+
+  // --- 2. Stack-based pass to build BranchSegments. ---
+  //
+  // Stack entries are one of two shapes:
+  //   { type: 'if',    groupId, branchIndex, segmentStart }
+  //   { type: 'block' }
+  //
+  // The 'block' entries represent non-if blocks (for, macro, etc.) that may
+  // themselves contain an `else` clause.  By tracking them on the same stack
+  // we ensure that an `else` or `elseif` token is only credited to the
+  // nearest enclosing `if`, not to an outer one.
+
+  /** @type {BranchSegment[]} */
+  const segments = [];
+  let groupId = 0;
+  /** @type {Array<{ type: 'if'; groupId: number; branchIndex: number; segmentStart: number } | { type: 'block' }>} */
+  const stack = [];
+
+  for (const token of classified) {
+    const top = stack.length > 0 ? stack[stack.length - 1] : null;
+
+    switch (token.role) {
+      case "START":
+        stack.push({
+          type: "if",
+          groupId: groupId++,
+          branchIndex: 0,
+          segmentStart: token.tokenEnd,
+        });
+        break;
+
+      case "BLOCK_OPEN":
+        stack.push({ type: "block" });
+        break;
+
+      case "CONTINUE":
+        // Only process when the immediately enclosing block is an if-block.
+        // A CONTINUE inside {% for %}...{% else %}...{% endfor %} will have
+        // a 'block' entry on top → ignored, so the outer if-block is safe.
+        if (top && top.type === "if") {
+          segments.push({
+            groupId: top.groupId,
+            branchIndex: top.branchIndex,
+            start: top.segmentStart,
+            end: token.tokenStart,
+          });
+          top.branchIndex++;
+          top.segmentStart = token.tokenEnd;
+        }
+        break;
+
+      case "END":
+        if (top && top.type === "if") {
+          stack.pop();
+          segments.push({
+            groupId: top.groupId,
+            branchIndex: top.branchIndex,
+            start: top.segmentStart,
+            end: token.tokenStart,
+          });
+        }
+        break;
+
+      case "BLOCK_CLOSE":
+        if (top && top.type === "block") {
+          stack.pop();
+        }
+        break;
+    }
+  }
+
+  return segments;
+}
+
+module.exports = {
+  computeBranchSegments,
+};

--- a/packages/parser/lib/branch-annotation.js
+++ b/packages/parser/lib/branch-annotation.js
@@ -1,3 +1,5 @@
+/** @import {TemplateSyntax} from "@html-eslint/template-syntax-parser" */
+
 /**
  * Branch annotation for @html-eslint/parser.
  *
@@ -33,7 +35,7 @@ function matches(pattern, content) {
 /**
  * Compute branch segments from a list of template token ranges.
  *
- * @param {Array<{ open: [number,number]; close: [number,number] }>} templateInfos
+ * @param {TemplateSyntax[]} templateInfos
  *   The TemplateSyntax[] returned by @html-eslint/template-syntax-parser.
  *   Each entry covers one complete template token: open is the [start,end]
  *   of the opening delimiter, close is the [start,end] of the closing
@@ -88,6 +90,7 @@ function computeBranchSegments(templateInfos, source, syntaxItems) {
     const content = source.slice(info.open[1], info.close[0]);
     const b = item.branch;
 
+    /** @type {'START'|'CONTINUE'|'END'|'BLOCK_OPEN'|'BLOCK_CLOSE'|null} */
     let role = null;
     // Order matters: END before CONTINUE so that patterns like
     // /^\s*-?\s*(elseif|else)\b/ don't accidentally match "endif" (they won't

--- a/packages/parser/lib/branch-annotation.js
+++ b/packages/parser/lib/branch-annotation.js
@@ -40,7 +40,7 @@ function matches(pattern, content) {
  * Compute branch segments from a list of template token ranges.
  *
  * @param {TemplateSyntax[]} templateInfos The TemplateSyntax[] returned by
- *   @html-eslint/template-syntax-parser. Each entry covers one complete
+ *   `@html-eslint/template-syntax-parser`. Each entry covers one complete
  *   template token: open is the [start,end] of the opening delimiter, close is
  *   the [start,end] of the closing delimiter. Content lives between open[1] and
  *   close[0].

--- a/packages/parser/lib/branch-annotation.js
+++ b/packages/parser/lib/branch-annotation.js
@@ -53,11 +53,11 @@ function matches(pattern, content) {
  *   open: string;
  *   close: string;
  *   branch?: {
- *     start: RegExp;
- *     continue: RegExp;
- *     end: RegExp;
- *     blockOpen?: RegExp;
- *     blockClose?: RegExp;
+ *     start: RegExp | string;
+ *     continue: RegExp | string;
+ *     end: RegExp | string;
+ *     blockOpen?: RegExp | string;
+ *     blockClose?: RegExp | string;
  *   };
  * }[]} syntaxItems
  *   Normalized SyntaxConfigItem array. Only items that have a .branch property

--- a/packages/parser/lib/branch-annotation.js
+++ b/packages/parser/lib/branch-annotation.js
@@ -3,6 +3,12 @@
 /**
  * Branch annotation for @html-eslint/parser.
  *
+ * @typedef {{
+ *   groupId: number;
+ *   branchIndex: number;
+ *   start: number;
+ *   end: number;
+ * }} BranchSegment
  * @html-eslint/template-syntax-parser already records every template token as
  * an opaque {open, close} range pair.  This module classifies those tokens
  * (using per-engine patterns stored in the SyntaxConfigItem.branch property)
@@ -17,8 +23,6 @@
  * Rules can use these segments to decide whether two "duplicate" nodes are
  * actually unreachable simultaneously, because every path through the template
  * can only enter one branch of any given if-block.
- *
- * @typedef {{ groupId: number; branchIndex: number; start: number; end: number }} BranchSegment
  */
 
 /**
@@ -35,33 +39,34 @@ function matches(pattern, content) {
 /**
  * Compute branch segments from a list of template token ranges.
  *
- * @param {TemplateSyntax[]} templateInfos
- *   The TemplateSyntax[] returned by @html-eslint/template-syntax-parser.
- *   Each entry covers one complete template token: open is the [start,end]
- *   of the opening delimiter, close is the [start,end] of the closing
- *   delimiter.  Content lives between open[1] and close[0].
- *
- * @param {string} source
- *   The source text that templateInfos was parsed from.  Must be the same
- *   string (same character offsets) — i.e. the frontmatter-stripped `html`
- *   string from getOptions(), NOT the full `code` string.  The caller is
- *   responsible for adding any frontmatter offset to the returned segments.
- *
- * @param {Array<{ open: string; close: string; branch?: {
- *   start:      RegExp;
- *   continue:   RegExp;
- *   end:        RegExp;
- *   blockOpen?:  RegExp;
- *   blockClose?: RegExp;
- * } }>} syntaxItems
- *   Normalized SyntaxConfigItem array.  Only items that have a .branch
- *   property are consulted; the rest are ignored.
- *
+ * @param {TemplateSyntax[]} templateInfos The TemplateSyntax[] returned by
+ *   @html-eslint/template-syntax-parser. Each entry covers one complete
+ *   template token: open is the [start,end] of the opening delimiter, close is
+ *   the [start,end] of the closing delimiter. Content lives between open[1] and
+ *   close[0].
+ * @param {string} source The source text that templateInfos was parsed from.
+ *   Must be the same string (same character offsets) — i.e. the
+ *   frontmatter-stripped `html` string from getOptions(), NOT the full `code`
+ *   string. The caller is responsible for adding any frontmatter offset to the
+ *   returned segments.
+ * @param {{
+ *   open: string;
+ *   close: string;
+ *   branch?: {
+ *     start: RegExp;
+ *     continue: RegExp;
+ *     end: RegExp;
+ *     blockOpen?: RegExp;
+ *     blockClose?: RegExp;
+ *   };
+ * }[]} syntaxItems
+ *   Normalized SyntaxConfigItem array. Only items that have a .branch property
+ *   are consulted; the rest are ignored.
  * @returns {BranchSegment[]}
  */
 function computeBranchSegments(templateInfos, source, syntaxItems) {
   // Fast exit: nothing to do without branch-aware items.
-  /** @type {Map<string, typeof syntaxItems[number]>} */
+  /** @type {Map<string, (typeof syntaxItems)[number]>} */
   const itemByOpen = new Map();
   for (const item of syntaxItems) {
     if (item.branch) {
@@ -73,11 +78,11 @@ function computeBranchSegments(templateInfos, source, syntaxItems) {
   // --- 1. Classify every token that belongs to a branch-aware delimiter. ---
 
   /**
-   * @type {Array<{
-   *   role: 'START'|'CONTINUE'|'END'|'BLOCK_OPEN'|'BLOCK_CLOSE';
+   * @type {{
+   *   role: "START" | "CONTINUE" | "END" | "BLOCK_OPEN" | "BLOCK_CLOSE";
    *   tokenStart: number;
    *   tokenEnd: number;
-   * }>}
+   * }[]}
    */
   const classified = [];
 
@@ -90,7 +95,14 @@ function computeBranchSegments(templateInfos, source, syntaxItems) {
     const content = source.slice(info.open[1], info.close[0]);
     const b = item.branch;
 
-    /** @type {'START'|'CONTINUE'|'END'|'BLOCK_OPEN'|'BLOCK_CLOSE'|null} */
+    /**
+     * @type {"START"
+     *   | "CONTINUE"
+     *   | "END"
+     *   | "BLOCK_OPEN"
+     *   | "BLOCK_CLOSE"
+     *   | null}
+     */
     let role = null;
     // Order matters: END before CONTINUE so that patterns like
     // /^\s*-?\s*(elseif|else)\b/ don't accidentally match "endif" (they won't
@@ -135,7 +147,17 @@ function computeBranchSegments(templateInfos, source, syntaxItems) {
   /** @type {BranchSegment[]} */
   const segments = [];
   let groupId = 0;
-  /** @type {Array<{ type: 'if'; groupId: number; branchIndex: number; segmentStart: number } | { type: 'block' }>} */
+  /**
+   * @type {(
+   *   | {
+   *       type: "if";
+   *       groupId: number;
+   *       branchIndex: number;
+   *       segmentStart: number;
+   *     }
+   *   | { type: "block" }
+   * )[]}
+   */
   const stack = [];
 
   for (const token of classified) {

--- a/packages/parser/lib/options.js
+++ b/packages/parser/lib/options.js
@@ -54,6 +54,10 @@ function getOptions(code, parserOptions) {
     };
   }
 
+  // Clone early so both templateSyntaxParser.parse and computeBranchSegments
+  // receive a mutable copy, even when the source is a frozen export.
+  const syntaxItems = normalizeSyntax(parserOptions.templateEngineSyntax);
+
   /** @type {any} */
   let tokenAdapter = undefined;
   let frontmatterOffset = 0;
@@ -92,7 +96,7 @@ function getOptions(code, parserOptions) {
   let templateInfos = undefined;
   if (parserOptions.templateEngineSyntax) {
     templateInfos = templateSyntaxParser.parse(html, {
-      syntax: parserOptions.templateEngineSyntax,
+      syntax: syntaxItems, // ← use the clone, not the frozen original
     }).syntax;
   }
 
@@ -102,8 +106,6 @@ function getOptions(code, parserOptions) {
   if (parserOptions.rawContentTags) {
     rawContentTags = parserOptions.rawContentTags;
   }
-
-  const syntaxItems = normalizeSyntax(parserOptions.templateEngineSyntax);
 
   if (templateInfos || tokenAdapter || rawContentTags) {
     return {

--- a/packages/parser/lib/options.js
+++ b/packages/parser/lib/options.js
@@ -6,10 +6,32 @@
 
 const templateSyntaxParser = require("@html-eslint/template-syntax-parser");
 const { parseFrontmatterContent } = require("./frontmatter");
+
+/**
+ * Normalize the templateEngineSyntax option to a plain SyntaxConfigItem[]
+ * so that the branch-annotation pass can inspect the `.branch` property on
+ * each item.  The template-syntax-parser performs the same normalization
+ * internally; we replicate it here rather than reaching into its internals.
+ *
+ * @param {ParserOptions["templateEngineSyntax"]} syntax
+ * @returns {Array<{ open: string; close: string; [key: string]: unknown }>}
+ */
+function normalizeSyntax(syntax) {
+  if (!syntax) return [];
+  if (Array.isArray(syntax)) return syntax;
+  // Record<string, string> short-hand form — no branch config possible.
+  return Object.entries(syntax).map(([open, close]) => ({ open, close }));
+}
+
 /**
  * @param {string} code
  * @param {ParserOptions | undefined} parserOptions
- * @returns {{ options: Parameters<ESHtmlParser["parse"]>[1]; html: string }}
+ * @returns {{
+ *   options: Parameters<ESHtmlParser["parse"]>[1];
+ *   html: string;
+ *   syntaxItems: Array<{ open: string; close: string; [key: string]: unknown }>;
+ *   frontmatterOffset: number;
+ * }}
  */
 function getOptions(code, parserOptions) {
   let html = code;
@@ -17,15 +39,20 @@ function getOptions(code, parserOptions) {
     return {
       options: undefined,
       html,
+      syntaxItems: [],
+      frontmatterOffset: 0,
     };
   }
 
   /** @type {any} */
   let tokenAdapter = undefined;
+  let frontmatterOffset = 0;
+
   if (parserOptions.frontmatter) {
     const result = parseFrontmatterContent(code);
     if (result) {
       html = result.html;
+      frontmatterOffset = result.index;
       const lineOffset = result.line - 1;
       tokenAdapter = {
         /** @param {any} token */
@@ -66,6 +93,8 @@ function getOptions(code, parserOptions) {
     rawContentTags = parserOptions.rawContentTags;
   }
 
+  const syntaxItems = normalizeSyntax(parserOptions.templateEngineSyntax);
+
   if (templateInfos || tokenAdapter || rawContentTags) {
     return {
       options: {
@@ -74,11 +103,15 @@ function getOptions(code, parserOptions) {
         rawContentTags,
       },
       html,
+      syntaxItems,
+      frontmatterOffset,
     };
   }
   return {
     options: undefined,
     html,
+    syntaxItems,
+    frontmatterOffset,
   };
 }
 

--- a/packages/parser/lib/options.js
+++ b/packages/parser/lib/options.js
@@ -20,10 +20,14 @@ function normalizeSyntax(syntax) {
   if (!syntax) return [];
   if (Array.isArray(syntax)) {
     // Return a shallow copy to avoid mutating frozen exports from @html-eslint/parser
-    return syntax.map((item) => ({
-      ...item,
-      branch: item.branch ? { ...item.branch } : undefined,
-    }));
+    return syntax.map(
+      /** @param {{ open: string; close: string; branch?: unknown }} item */
+      (item) => ({
+        open: item.open,
+        close: item.close,
+        ...(item.branch ? { branch: { ...item.branch } } : {}),
+      })
+    );
   }
   // Record<string, string> shorthand form — no branch config possible.
   return Object.entries(syntax).map(([open, close]) => ({ open, close }));

--- a/packages/parser/lib/options.js
+++ b/packages/parser/lib/options.js
@@ -18,8 +18,14 @@ const { parseFrontmatterContent } = require("./frontmatter");
  */
 function normalizeSyntax(syntax) {
   if (!syntax) return [];
-  if (Array.isArray(syntax)) return syntax;
-  // Record<string, string> short-hand form — no branch config possible.
+  if (Array.isArray(syntax)) {
+    // Return a shallow copy to avoid mutating frozen exports from @html-eslint/parser
+    return syntax.map((item) => ({
+      ...item,
+      branch: item.branch ? { ...item.branch } : undefined,
+    }));
+  }
+  // Record<string, string> shorthand form — no branch config possible.
   return Object.entries(syntax).map(([open, close]) => ({ open, close }));
 }
 

--- a/packages/parser/lib/options.js
+++ b/packages/parser/lib/options.js
@@ -8,13 +8,13 @@ const templateSyntaxParser = require("@html-eslint/template-syntax-parser");
 const { parseFrontmatterContent } = require("./frontmatter");
 
 /**
- * Normalize the templateEngineSyntax option to a plain SyntaxConfigItem[]
- * so that the branch-annotation pass can inspect the `.branch` property on
- * each item.  The template-syntax-parser performs the same normalization
- * internally; we replicate it here rather than reaching into its internals.
+ * Normalize the templateEngineSyntax option to a plain SyntaxConfigItem[] so
+ * that the branch-annotation pass can inspect the `.branch` property on each
+ * item. The template-syntax-parser performs the same normalization internally;
+ * we replicate it here rather than reaching into its internals.
  *
  * @param {ParserOptions["templateEngineSyntax"]} syntax
- * @returns {Array<{ open: string; close: string; [key: string]: unknown }>}
+ * @returns {{ open: string; close: string; [key: string]: unknown }[]}
  */
 function normalizeSyntax(syntax) {
   if (!syntax) return [];
@@ -29,7 +29,7 @@ function normalizeSyntax(syntax) {
  * @returns {{
  *   options: Parameters<ESHtmlParser["parse"]>[1];
  *   html: string;
- *   syntaxItems: Array<{ open: string; close: string; [key: string]: unknown }>;
+ *   syntaxItems: { open: string; close: string; [key: string]: unknown }[];
  *   frontmatterOffset: number;
  * }}
  */

--- a/packages/parser/lib/parser.js
+++ b/packages/parser/lib/parser.js
@@ -11,6 +11,7 @@ const { traverse, traverseCss } = require("./traverse");
 const { NODE_TYPES } = require("./node-types");
 const { getOptions } = require("./options");
 const { parse: parseCSS, toPlainObject } = require("css-tree");
+const { computeBranchSegments } = require("./branch-annotation");
 
 /**
  * @param {string} code
@@ -18,8 +19,12 @@ const { parse: parseCSS, toPlainObject } = require("css-tree");
  * @returns {Linter.ESLintParseResult}
  */
 module.exports.parseForESLint = function parseForESLint(code, parserOptions) {
-  const { options, html } = getOptions(code, parserOptions);
+  const { options, html, syntaxItems, frontmatterOffset } = getOptions(
+    code,
+    parserOptions
+  );
   const { ast, tokens } = parse(html, options);
+
   /** @type {HTMLProgram} */
   const programNode = {
     type: "Program",
@@ -36,6 +41,35 @@ module.exports.parseForESLint = function parseForESLint(code, parserOptions) {
     ),
     comments: [],
   };
+
+  // Compute branch segments from the template token list produced by
+  // @html-eslint/template-syntax-parser.  Rules (no-duplicate-id, etc.) read
+  // these segments to decide whether "duplicate" nodes are actually confined
+  // to mutually exclusive runtime branches.
+  //
+  // templateInfos ranges are relative to `html` (frontmatter-stripped source).
+  // AST node ranges are relative to the original `code` (via tokenAdapter).
+  // We therefore add frontmatterOffset to each segment after computing them.
+  const templateInfos =
+    (options && options.templateInfos) || [];
+
+  if (templateInfos.length > 0 && syntaxItems.length > 0) {
+    const rawSegments = computeBranchSegments(templateInfos, html, syntaxItems);
+    // @ts-ignore — branchSegments is not part of the typed HTMLProgram
+    // definition, but rules access it dynamically via sourceCode.ast.
+    programNode.branchSegments =
+      frontmatterOffset === 0
+        ? rawSegments
+        : rawSegments.map((seg) => ({
+            groupId: seg.groupId,
+            branchIndex: seg.branchIndex,
+            start: seg.start + frontmatterOffset,
+            end: seg.end + frontmatterOffset,
+          }));
+  } else {
+    // @ts-ignore
+    programNode.branchSegments = [];
+  }
 
   traverse(programNode, (node) => {
     if (node.type === NODE_TYPES.CommentContent) {

--- a/packages/parser/lib/parser.js
+++ b/packages/parser/lib/parser.js
@@ -4,6 +4,7 @@
  *   HTMLProgram,
  *   ParserOptions
  * } from "./types"
+ * @import {TemplateSyntax} from "@html-eslint/template-syntax-parser"
  */
 const { parse, TokenTypes } = require("es-html-parser");
 const { visitorKeys } = require("./visitor-keys");
@@ -50,8 +51,12 @@ module.exports.parseForESLint = function parseForESLint(code, parserOptions) {
   // templateInfos ranges are relative to `html` (frontmatter-stripped source).
   // AST node ranges are relative to the original `code` (via tokenAdapter).
   // We therefore add frontmatterOffset to each segment after computing them.
-  const templateInfos =
-    (options && options.templateInfos) || [];
+  // options.templateInfos is typed as TemplateInfo[] by es-html-parser's
+  // declarations, but at runtime it is always TemplateSyntax[] produced by
+  // @html-eslint/template-syntax-parser.  The cast is safe.
+  const templateInfos = /** @type {TemplateSyntax[]} */ (
+    (options && options.templateInfos) || []
+  );
 
   if (templateInfos.length > 0 && syntaxItems.length > 0) {
     const rawSegments = computeBranchSegments(templateInfos, html, syntaxItems);

--- a/packages/parser/lib/parser.js
+++ b/packages/parser/lib/parser.js
@@ -1,10 +1,10 @@
 /**
+ * @import {TemplateSyntax} from "@html-eslint/template-syntax-parser"
  * @import {Linter} from "eslint"
  * @import {
  *   HTMLProgram,
  *   ParserOptions
  * } from "./types"
- * @import {TemplateSyntax} from "@html-eslint/template-syntax-parser"
  */
 const { parse, TokenTypes } = require("es-html-parser");
 const { visitorKeys } = require("./visitor-keys");

--- a/packages/parser/lib/parser.js
+++ b/packages/parser/lib/parser.js
@@ -12,7 +12,10 @@ const { traverse, traverseCss } = require("./traverse");
 const { NODE_TYPES } = require("./node-types");
 const { getOptions } = require("./options");
 const { parse: parseCSS, toPlainObject } = require("css-tree");
-const { computeBranchSegments } = require("./branch-annotation");
+const {
+  computeBranchSegments,
+  getControlTokenRanges,
+} = require("./branch-annotation");
 
 /**
  * @param {string} code
@@ -60,6 +63,11 @@ module.exports.parseForESLint = function parseForESLint(code, parserOptions) {
 
   if (templateInfos.length > 0 && syntaxItems.length > 0) {
     const rawSegments = computeBranchSegments(templateInfos, html, syntaxItems);
+    const rawControlRanges = getControlTokenRanges(
+      templateInfos,
+      html,
+      syntaxItems
+    );
     // @ts-ignore — branchSegments is not part of the typed HTMLProgram
     // definition, but rules access it dynamically via sourceCode.ast.
     programNode.branchSegments =
@@ -71,9 +79,23 @@ module.exports.parseForESLint = function parseForESLint(code, parserOptions) {
             start: seg.start + frontmatterOffset,
             end: seg.end + frontmatterOffset,
           }));
+    // @ts-ignore — branchControlRanges is not part of the typed HTMLProgram
+    // definition. Rules use it to tell a branch-control template token
+    // (e.g. {% if %} / {% else %} / {% endif %}) apart from a plain
+    // value-interpolation token (e.g. {{ name }}) when a template token
+    // ends up glued onto adjacent text with no separating whitespace.
+    programNode.branchControlRanges =
+      frontmatterOffset === 0
+        ? rawControlRanges
+        : rawControlRanges.map(([start, end]) => [
+            start + frontmatterOffset,
+            end + frontmatterOffset,
+          ]);
   } else {
     // @ts-ignore
     programNode.branchSegments = [];
+    // @ts-ignore
+    programNode.branchControlRanges = [];
   }
 
   traverse(programNode, (node) => {

--- a/packages/parser/lib/template-engine-syntax-preset.js
+++ b/packages/parser/lib/template-engine-syntax-preset.js
@@ -15,7 +15,7 @@
  *   continue:    RegExp;   // matches branch-separator tokens (elseif / else)
  *   end:         RegExp;   // matches if-closing tokens  (e.g. " endif ")
  *   blockOpen?:  RegExp;   // matches other block-openers (for, macro, …)
- *   blockClose?: RegExp;   // matches the matching closers (endfor, endmacro, …)
+ *   blockClose?: RegExp;   // matches the matching closers (endfor, …)
  * }} BranchConfig
  *
  * blockOpen / blockClose are needed to prevent an `else` or `elif` that

--- a/packages/parser/lib/template-engine-syntax-preset.js
+++ b/packages/parser/lib/template-engine-syntax-preset.js
@@ -1,16 +1,117 @@
 /** @import {SyntaxConfig} from "@html-eslint/template-syntax-parser" */
 
+/**
+ * Branch configuration for a template block delimiter.
+ *
+ * The template-syntax-parser ignores unknown properties on SyntaxConfigItem,
+ * so adding `branch` here is fully backwards-compatible.
+ *
+ * Patterns are matched against the raw content between the opening and closing
+ * delimiters of each template token, e.g. the content of `{% if foo %}` is
+ * " if foo " (including surrounding whitespace).
+ *
+ * @typedef {{
+ *   start:       RegExp;   // matches if-opening tokens  (e.g. " if cond ")
+ *   continue:    RegExp;   // matches branch-separator tokens (elseif / else)
+ *   end:         RegExp;   // matches if-closing tokens  (e.g. " endif ")
+ *   blockOpen?:  RegExp;   // matches other block-openers (for, macro, …)
+ *   blockClose?: RegExp;   // matches the matching closers (endfor, endmacro, …)
+ * }} BranchConfig
+ *
+ * blockOpen / blockClose are needed to prevent an `else` or `elif` that
+ * belongs to a `for` / `macro` / etc. block from being misclassified as an
+ * `else` belonging to an enclosing `if` block.
+ */
+
+// ---------------------------------------------------------------------------
+// HANDLEBAR
+// ---------------------------------------------------------------------------
+
 /** @type {SyntaxConfig} */
 const HANDLEBAR = {
   "{{": "}}",
 };
 
-/** @type {SyntaxConfig} */
+/**
+ * Handlebars with conditional branch-awareness.
+ * Use this instead of HANDLEBAR when you want duplicate nodes that appear in
+ * separate `{{#if}}` / `{{else}}` branches to be silently ignored.
+ *
+ * Must be used as an array (SyntaxConfigItem[]) rather than the shorthand
+ * Record form, because the Record form has no place to carry branch patterns.
+ *
+ * @type {Array<{ open: string; close: string; branch: BranchConfig }>}
+ */
+const HANDLEBAR_EXTENDED = [
+  {
+    open: "{{",
+    close: "}}",
+    branch: {
+      start:      /^\s*#if\b/,
+      continue:   /^\s*else\b/,
+      end:        /^\s*\/if\b/,
+      // Any block helper other than #if / /if may carry its own {{else}}.
+      blockOpen:  /^\s*#(?!if\b)/,
+      blockClose: /^\s*\/(?!if\b)/,
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// TWIG
+// ---------------------------------------------------------------------------
+
+/**
+ * Twig branch patterns.
+ * Handles optional whitespace-control dashes: {%- ... -%}
+ * The `-` appears as the first non-space character of the token content.
+ *
+ * @type {BranchConfig}
+ */
+const TWIG_BRANCH = {
+  start:      /^\s*-?\s*if\b/,
+  continue:   /^\s*-?\s*(elseif|else)\b/,
+  end:        /^\s*-?\s*endif\b/,
+  blockOpen:  /^\s*-?\s*(for|block|macro|embed|autoescape|sandbox|with)\b/,
+  blockClose: /^\s*-?\s*end(for|block|macro|embed|autoescape|sandbox|with)\b/,
+};
+
+/** @type {Array<{ open: string; close: string; isComment?: boolean; branch?: BranchConfig }>} */
 const TWIG = [
   { open: "{{", close: "}}" },
-  { open: "{%", close: "%}" },
+  { open: "{%", close: "%}", branch: TWIG_BRANCH },
   { open: "{#", close: "#}", isComment: true },
 ];
+
+// ---------------------------------------------------------------------------
+// NUNJUCKS
+// Identical delimiter syntax to Twig but uses `elif` instead of `elseif`,
+// and its block keyword inventory differs slightly.
+// ---------------------------------------------------------------------------
+
+/** @type {Array<{ open: string; close: string; isComment?: boolean; branch?: BranchConfig }>} */
+const NUNJUCKS = [
+  { open: "{{", close: "}}" },
+  {
+    open: "{%",
+    close: "%}",
+    branch: {
+      start:      /^\s*-?\s*if\b/,
+      continue:   /^\s*-?\s*(elif|else)\b/,
+      end:        /^\s*-?\s*endif\b/,
+      blockOpen:  /^\s*-?\s*(for|block|macro|call|set)\b/,
+      blockClose: /^\s*-?\s*end(for|block|macro|call|set)\b/,
+    },
+  },
+  { open: "{#", close: "#}", isComment: true },
+];
+
+// ---------------------------------------------------------------------------
+// ERB
+// Not branch-aware: ERB's `end` keyword is shared by every block type
+// (if, unless, while, each, …), making reliable if-block tracking impossible
+// without a full Ruby expression parser.
+// ---------------------------------------------------------------------------
 
 /** @type {SyntaxConfig} */
 const ERB = {
@@ -19,6 +120,8 @@ const ERB = {
 
 module.exports = {
   HANDLEBAR,
+  HANDLEBAR_EXTENDED,
   TWIG,
+  NUNJUCKS,
   ERB,
 };

--- a/packages/parser/lib/template-engine-syntax-preset.js
+++ b/packages/parser/lib/template-engine-syntax-preset.js
@@ -3,24 +3,23 @@
 /**
  * Branch configuration for a template block delimiter.
  *
- * The template-syntax-parser ignores unknown properties on SyntaxConfigItem,
- * so adding `branch` here is fully backwards-compatible.
+ * The template-syntax-parser ignores unknown properties on SyntaxConfigItem, so
+ * adding `branch` here is fully backwards-compatible.
  *
  * Patterns are matched against the raw content between the opening and closing
- * delimiters of each template token, e.g. the content of `{% if foo %}` is
- * " if foo " (including surrounding whitespace).
+ * delimiters of each template token, e.g. the content of `{% if foo %}` is " if
+ * foo " (including surrounding whitespace).
  *
  * @typedef {{
- *   start:       RegExp;   // matches if-opening tokens  (e.g. " if cond ")
- *   continue:    RegExp;   // matches branch-separator tokens (elseif / else)
- *   end:         RegExp;   // matches if-closing tokens  (e.g. " endif ")
- *   blockOpen?:  RegExp;   // matches other block-openers (for, macro, …)
- *   blockClose?: RegExp;   // matches the matching closers (endfor, …)
+ *   start: RegExp; // matches if-opening tokens  (e.g. " if cond ")
+ *   continue: RegExp; // matches branch-separator tokens (elseif / else)
+ *   end: RegExp; // matches if-closing tokens  (e.g. " endif ")
+ *   blockOpen?: RegExp; // matches other block-openers (for, macro, …)
+ *   blockClose?: RegExp; // matches the matching closers (endfor, …)
  * }} BranchConfig
- *
- * blockOpen / blockClose are needed to prevent an `else` or `elif` that
- * belongs to a `for` / `macro` / etc. block from being misclassified as an
- * `else` belonging to an enclosing `if` block.
+ *   BlockOpen / blockClose are needed to prevent an `else` or `elif` that belongs
+ *   to a `for` / `macro` / etc. block from being misclassified as an `else`
+ *   belonging to an enclosing `if` block.
  */
 
 // ---------------------------------------------------------------------------
@@ -33,25 +32,25 @@ const HANDLEBAR = {
 };
 
 /**
- * Handlebars with conditional branch-awareness.
- * Use this instead of HANDLEBAR when you want duplicate nodes that appear in
- * separate `{{#if}}` / `{{else}}` branches to be silently ignored.
+ * Handlebars with conditional branch-awareness. Use this instead of HANDLEBAR
+ * when you want duplicate nodes that appear in separate `{{#if}}` / `{{else}}`
+ * branches to be silently ignored.
  *
  * Must be used as an array (SyntaxConfigItem[]) rather than the shorthand
  * Record form, because the Record form has no place to carry branch patterns.
  *
- * @type {Array<{ open: string; close: string; branch: BranchConfig }>}
+ * @type {{ open: string; close: string; branch: BranchConfig }[]}
  */
 const HANDLEBAR_EXTENDED = [
   {
     open: "{{",
     close: "}}",
     branch: {
-      start:      /^\s*#if\b/,
-      continue:   /^\s*else\b/,
-      end:        /^\s*\/if\b/,
+      start: /^\s*#if\b/,
+      continue: /^\s*else\b/,
+      end: /^\s*\/if\b/,
       // Any block helper other than #if / /if may carry its own {{else}}.
-      blockOpen:  /^\s*#(?!if\b)/,
+      blockOpen: /^\s*#(?!if\b)/,
       blockClose: /^\s*\/(?!if\b)/,
     },
   },
@@ -62,21 +61,27 @@ const HANDLEBAR_EXTENDED = [
 // ---------------------------------------------------------------------------
 
 /**
- * Twig branch patterns.
- * Handles optional whitespace-control dashes: {%- ... -%}
+ * Twig branch patterns. Handles optional whitespace-control dashes: {%- ... -%}
  * The `-` appears as the first non-space character of the token content.
  *
  * @type {BranchConfig}
  */
 const TWIG_BRANCH = {
-  start:      /^\s*-?\s*if\b/,
-  continue:   /^\s*-?\s*(elseif|else)\b/,
-  end:        /^\s*-?\s*endif\b/,
-  blockOpen:  /^\s*-?\s*(for|block|macro|embed|autoescape|sandbox|with)\b/,
+  start: /^\s*-?\s*if\b/,
+  continue: /^\s*-?\s*(elseif|else)\b/,
+  end: /^\s*-?\s*endif\b/,
+  blockOpen: /^\s*-?\s*(for|block|macro|embed|autoescape|sandbox|with)\b/,
   blockClose: /^\s*-?\s*end(for|block|macro|embed|autoescape|sandbox|with)\b/,
 };
 
-/** @type {Array<{ open: string; close: string; isComment?: boolean; branch?: BranchConfig }>} */
+/**
+ * @type {{
+ *   open: string;
+ *   close: string;
+ *   isComment?: boolean;
+ *   branch?: BranchConfig;
+ * }[]}
+ */
 const TWIG = [
   { open: "{{", close: "}}" },
   { open: "{%", close: "%}", branch: TWIG_BRANCH },
@@ -89,17 +94,24 @@ const TWIG = [
 // and its block keyword inventory differs slightly.
 // ---------------------------------------------------------------------------
 
-/** @type {Array<{ open: string; close: string; isComment?: boolean; branch?: BranchConfig }>} */
+/**
+ * @type {{
+ *   open: string;
+ *   close: string;
+ *   isComment?: boolean;
+ *   branch?: BranchConfig;
+ * }[]}
+ */
 const NUNJUCKS = [
   { open: "{{", close: "}}" },
   {
     open: "{%",
     close: "%}",
     branch: {
-      start:      /^\s*-?\s*if\b/,
-      continue:   /^\s*-?\s*(elif|else)\b/,
-      end:        /^\s*-?\s*endif\b/,
-      blockOpen:  /^\s*-?\s*(for|block|macro|call|set)\b/,
+      start: /^\s*-?\s*if\b/,
+      continue: /^\s*-?\s*(elif|else)\b/,
+      end: /^\s*-?\s*endif\b/,
+      blockOpen: /^\s*-?\s*(for|block|macro|call|set)\b/,
       blockClose: /^\s*-?\s*end(for|block|macro|call|set)\b/,
     },
   },

--- a/packages/parser/tests/branch-annotation.test.js
+++ b/packages/parser/tests/branch-annotation.test.js
@@ -5,6 +5,20 @@ const {
   HANDLEBAR_EXTENDED,
 } = require("../lib/template-engine-syntax-preset");
 
+// Custom config using STRING patterns instead of RegExp to hit
+// the indexOf() fallback path in matches().
+const STRING_PATTERN_CONFIG = [
+  {
+    open: "{%",
+    close: "%}",
+    branch: {
+      start: "if", // string, not RegExp
+      continue: "elseif", // string
+      end: "endif", // string
+    },
+  },
+];
+
 // ---------------------------------------------------------------------------
 // Test helpers — replicate what @html-eslint/template-syntax-parser produces:
 // open = [startOfDelim, endOfDelim], close = [startOfCloseDelim, endOfCloseDelim].
@@ -208,6 +222,19 @@ describe("computeBranchSegments", () => {
       extractHbsTagInfos(source),
       source,
       HANDLEBAR_EXTENDED
+    );
+    expect(segments).toHaveLength(2);
+    expect(new Set(segments.map((s) => s.groupId)).size).toBe(1);
+  });
+
+  // ── String pattern fallback ───────────────────────────────────────────────
+
+  it("uses string patterns (indexOf fallback) instead of RegExp", () => {
+    const source = "{% if cond %}A{% elseif x %}B{% endif %}";
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      STRING_PATTERN_CONFIG
     );
     expect(segments).toHaveLength(2);
     expect(new Set(segments.map((s) => s.groupId)).size).toBe(1);

--- a/packages/parser/tests/branch-annotation.test.js
+++ b/packages/parser/tests/branch-annotation.test.js
@@ -1,0 +1,215 @@
+const { computeBranchSegments } = require("../lib/branch-annotation");
+const {
+  TWIG,
+  NUNJUCKS,
+  HANDLEBAR_EXTENDED,
+} = require("../lib/template-engine-syntax-preset");
+
+// ---------------------------------------------------------------------------
+// Test helpers — replicate what @html-eslint/template-syntax-parser produces:
+// open = [startOfDelim, endOfDelim], close = [startOfCloseDelim, endOfCloseDelim].
+// The whitespace-control dash ('-') in '{%-' is CONTENT, not part of the '{%'
+// delimiter — so open is always exactly [pos, pos+2] for '{%' tokens.
+// ---------------------------------------------------------------------------
+
+/** @param {string} source */
+function extractTwigTagInfos(source) {
+  const infos = [];
+  const re = /\{%([\s\S]*?)%\}/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    infos.push({
+      open: [m.index, m.index + 2],
+      close: [m.index + 2 + m[1].length, m.index + m[0].length],
+    });
+  }
+  return infos;
+}
+
+/** @param {string} source */
+function extractHbsTagInfos(source) {
+  const infos = [];
+  const re = /\{\{([\s\S]*?)\}\}/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    infos.push({
+      open: [m.index, m.index + 2],
+      close: [m.index + 2 + m[1].length, m.index + m[0].length],
+    });
+  }
+  return infos;
+}
+
+// ---------------------------------------------------------------------------
+
+describe("computeBranchSegments", () => {
+  // ── degenerate cases ──────────────────────────────────────────────────────
+
+  it("returns empty array when templateInfos is empty", () => {
+    expect(computeBranchSegments([], "<p>hi</p>", TWIG)).toEqual([]);
+  });
+
+  it("returns empty array when no syntax item has a branch config", () => {
+    const source = "{% if x %}A{% endif %}";
+    const infos = extractTwigTagInfos(source);
+    // Syntax items without .branch property
+    const items = [{ open: "{%", close: "%}" }];
+    expect(computeBranchSegments(infos, source, items)).toEqual([]);
+  });
+
+  it("returns empty array when syntaxItems is empty", () => {
+    const source = "{% if x %}A{% endif %}";
+    const infos = extractTwigTagInfos(source);
+    expect(computeBranchSegments(infos, source, [])).toEqual([]);
+  });
+
+  // ── Twig: basic if / else ─────────────────────────────────────────────────
+
+  it("produces two segments for a simple if/else block", () => {
+    const source = "{% if cond %}yes{% else %}no{% endif %}";
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    expect(segments).toHaveLength(2);
+    expect(new Set(segments.map((s) => s.groupId)).size).toBe(1);
+    expect(segments[0].branchIndex).toBe(0);
+    expect(segments[1].branchIndex).toBe(1);
+    // Branch 0 content is "yes"
+    expect(source.slice(segments[0].start, segments[0].end)).toBe("yes");
+    // Branch 1 content is "no"
+    expect(source.slice(segments[1].start, segments[1].end)).toBe("no");
+  });
+
+  // ── Twig: if / elseif / else / endif ─────────────────────────────────────
+
+  it("produces three segments for if/elseif/else/endif", () => {
+    const source = [
+      "{% if a %}",
+      "body_a",
+      "{% elseif b %}",
+      "body_b",
+      "{% else %}",
+      "body_c",
+      "{% endif %}",
+    ].join("\n");
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    expect(segments).toHaveLength(3);
+    expect(new Set(segments.map((s) => s.groupId)).size).toBe(1);
+    expect(segments.map((s) => s.branchIndex)).toEqual([0, 1, 2]);
+  });
+
+  // ── Twig: only-if (no else) ───────────────────────────────────────────────
+
+  it("produces one segment for a plain if block without else", () => {
+    const source = "{% if cond %}content{% endif %}";
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    expect(segments).toHaveLength(1);
+    expect(segments[0].branchIndex).toBe(0);
+  });
+
+  // ── Twig: for/else inside if must not corrupt outer if tracking ───────────
+
+  it("ignores for-else inside an if block (blockOpen/blockClose)", () => {
+    const source = [
+      "{% if cond %}",
+      "  {% for x in xs %}item{% else %}empty{% endfor %}",
+      "{% else %}",
+      "  B",
+      "{% endif %}",
+    ].join("\n");
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    // The for-else must NOT be credited to the outer if-block.
+    expect(segments).toHaveLength(2);
+    expect(new Set(segments.map((s) => s.groupId)).size).toBe(1);
+  });
+
+  // ── Twig: whitespace-control dashes ──────────────────────────────────────
+
+  it("handles whitespace-control dashes on if/else/endif tokens", () => {
+    const source = "{%- if cond -%}yes{%- else -%}no{%- endif -%}";
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    expect(segments).toHaveLength(2);
+  });
+
+  // ── Twig: two separate if-blocks produce two independent groups ───────────
+
+  it("creates separate groups for two independent if blocks", () => {
+    const source = "{% if c1 %}A{% endif %}\n{% if c2 %}B{% endif %}";
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    expect(segments).toHaveLength(2);
+    expect(new Set(segments.map((s) => s.groupId)).size).toBe(2);
+  });
+
+  // ── Twig: nested if blocks ────────────────────────────────────────────────
+
+  it("handles nested if blocks (outer 2 branches + inner 1 branch)", () => {
+    const source =
+      "{% if outer %}{% if inner %}A{% endif %}{% else %}B{% endif %}";
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    expect(segments).toHaveLength(3);
+    expect(new Set(segments.map((s) => s.groupId)).size).toBe(2);
+  });
+
+  // ── Nunjucks: elif keyword ────────────────────────────────────────────────
+
+  it("handles Nunjucks elif keyword", () => {
+    const source = "{% if a %}\nA\n{% elif b %}\nB\n{% else %}\nC\n{% endif %}";
+    const segments = computeBranchSegments(
+      extractTwigTagInfos(source),
+      source,
+      NUNJUCKS
+    );
+    expect(segments).toHaveLength(3);
+    expect(segments.map((s) => s.branchIndex)).toEqual([0, 1, 2]);
+  });
+
+  // ── Handlebars EXTENDED: #if / else / /if ─────────────────────────────────
+
+  it("handles Handlebars #if / else / /if", () => {
+    const source = "{{#if cond}}yes{{else}}no{{/if}}";
+    const segments = computeBranchSegments(
+      extractHbsTagInfos(source),
+      source,
+      HANDLEBAR_EXTENDED
+    );
+    expect(segments).toHaveLength(2);
+  });
+
+  it("ignores Handlebars #each/else inside a #if block", () => {
+    const source =
+      "{{#if cond}}{{#each items}}item{{else}}empty{{/each}}{{else}}B{{/if}}";
+    const segments = computeBranchSegments(
+      extractHbsTagInfos(source),
+      source,
+      HANDLEBAR_EXTENDED
+    );
+    expect(segments).toHaveLength(2);
+    expect(new Set(segments.map((s) => s.groupId)).size).toBe(1);
+  });
+});

--- a/packages/parser/tests/branch-annotation.test.js
+++ b/packages/parser/tests/branch-annotation.test.js
@@ -12,9 +12,9 @@ const STRING_PATTERN_CONFIG = [
     open: "{%",
     close: "%}",
     branch: {
-      start: "if", // string, not RegExp
-      continue: "elseif", // string
-      end: "endif", // string
+      start: " if", // string, not RegExp
+      continue: " elseif", // string
+      end: " endif", // string
     },
   },
 ];

--- a/packages/parser/tests/branch-annotation.test.js
+++ b/packages/parser/tests/branch-annotation.test.js
@@ -1,4 +1,7 @@
-const { computeBranchSegments } = require("../lib/branch-annotation");
+const {
+  computeBranchSegments,
+  getControlTokenRanges,
+} = require("../lib/branch-annotation");
 const {
   TWIG,
   NUNJUCKS,
@@ -238,5 +241,77 @@ describe("computeBranchSegments", () => {
     );
     expect(segments).toHaveLength(2);
     expect(new Set(segments.map((s) => s.groupId)).size).toBe(1);
+  });
+});
+
+describe("getControlTokenRanges", () => {
+  it("returns the [start, end] range of each branch-control token", () => {
+    const source = "{% if cond %}yes{% else %}no{% endif %}";
+    const ranges = getControlTokenRanges(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    expect(ranges).toEqual([
+      [0, 13],
+      [16, 26],
+      [28, 39],
+    ]);
+    // Each range slices back to the exact token text.
+    expect(ranges.map(([s, e]) => source.slice(s, e))).toEqual([
+      "{% if cond %}",
+      "{% else %}",
+      "{% endif %}",
+    ]);
+  });
+
+  it("returns an empty array when templateInfos is empty", () => {
+    const source = "{% if cond %}yes{% endif %}";
+    expect(getControlTokenRanges([], source, TWIG)).toEqual([]);
+  });
+
+  it("returns an empty array when no syntax item has a branch config", () => {
+    const source = "{% if cond %}yes{% endif %}";
+    const infos = extractTwigTagInfos(source);
+    const items = [{ open: "{%", close: "%}" }];
+    expect(getControlTokenRanges(infos, source, items)).toEqual([]);
+  });
+
+  it("excludes non-control tokens such as a plain output tag", () => {
+    // TWIG's `{{ }}` delimiter has no .branch config, so a value
+    // interpolation token must never show up as a control token even when
+    // it sits right next to a real if/else/endif block.
+    const source = "{% if cond %}{{ name }}{% endif %}";
+    const infos = [
+      { open: [0, 2], close: [11, 13] }, // {% if cond %}
+      { open: [13, 15], close: [21, 23] }, // {{ name }}
+      { open: [23, 25], close: [32, 34] }, // {% endif %}
+    ];
+    const ranges = getControlTokenRanges(infos, source, TWIG);
+    expect(ranges).toEqual([
+      [0, 13],
+      [23, 34],
+    ]);
+  });
+
+  it("only includes tokens classified via blockOpen/blockClose, not plain nested blocks left unclassified", () => {
+    const source = [
+      "{% if cond %}",
+      "  {% for x in xs %}item{% else %}empty{% endfor %}",
+      "{% else %}",
+      "  B",
+      "{% endif %}",
+    ].join("\n");
+    const ranges = getControlTokenRanges(
+      extractTwigTagInfos(source),
+      source,
+      TWIG
+    );
+    // if, for, for-else, endfor, else, endif — all six are classified
+    // (for/endfor as BLOCK_OPEN/BLOCK_CLOSE, for-else as CONTINUE consumed
+    // by the for-block, if/else/endif as the outer if-block tokens), so all
+    // six token ranges are present in the control-token list even though
+    // the for-else does not produce a BranchSegment.
+    expect(ranges).toHaveLength(6);
   });
 });


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: fixes #409

## Description

This update helps ignore legitimate duplicates in templates branches (like `if`).

After feeding comments from #409 into my conversation with Claude about possible solution for the duplicates in templates, it said this:

> **Where you're right**
> 
> The customizable syntax point is real but slightly overstated. In practice, virtually nobody changes Twig's default delimiters — it's an edge case that exists in the spec but rarely in production codebases. An author could reasonably say "we support standard Twig syntax; non-standard delimiter configurations are out of scope." That's a defensible product decision, not a technical failure. So that argument shouldn't be the main objection to the author's approach.
> 
> Your stronger point is the multiple-AST problem. That one is genuinely hard and you're right to raise it. If the parser produces a branching AST node like `IfBlock { branches: [Branch[], Branch[]] }`, then every rule that currently walks a flat `Tag[]` sequence needs to be rewritten to understand that structure. That's not just the four duplicate rules — it's the entire rule set. That's a significant backwards-compatibility break and a large maintenance surface.
> 
> **Where the author is right**
> 
> The fundamental critique of the pattern-matching approach is also valid: regex scanning raw source text to recover structure that should have been parsed in the first place is fragile. It works for the common cases but it's not the same thing as actually understanding the template. The current implementation would mishandle, for example, a Twig `{% if %}` inside a comment, or inside a raw string attribute value, or nested inside a macro definition. These are corner cases, but a parser would handle them correctly by construction.
> 
> **The realistic middle path**
> 
> Neither "regex heuristics on raw source" nor "full separate AST per template engine" is the right long-term answer. The realistic option the author hasn't mentioned is what several other multi-language linting tools do: **annotate the existing flat AST with branch metadata rather than restructuring it**.
> 
> Concretely: the parser already tracks `templateInfos` — the ranges of all template tokens. The extension would be to also classify those tokens into roles: `BRANCH_OPEN`, `BRANCH_CONTINUE`, `BRANCH_CLOSE`. Each `Tag` node then gets an optional `branchId` and `branchIndex` annotation added during the parse traversal. Rules can check these annotations without their structure changing at all. The visitor pattern stays flat. Backwards compatibility is preserved. And the classification is done inside the parser where it has full context (so no regex-over-raw-source fragility).
> 
> This is essentially what JSX parsers do with conditional rendering — they don't produce a separate AST shape for `condition ? <A/> : <B/>`, they annotate the expression nodes.
> 
> The cost of this approach is that the parser needs per-engine knowledge of which token content means "branch continues here" — which brings SyntaxConfig back into the picture exactly as you suggested to the author. So your instinct about SyntaxConfig needing extension was pointing in the right direction, just at the wrong layer: it belongs in the parser producing annotations, not in the rules consuming them.

Had to push it to actually write code a bit, and then it did. I tested it, and it does seem to work, at least with Twig examples, that I shared earlier. Please, let me know in case of any concerns. Same as with my previous PR I will try to address all issues raised by CI, too.