### PR TITLE
test: ensure every exported rule has a test file

### DIFF
--- a/packages/eslint-plugin/tests/configs.test.js
+++ b/packages/eslint-plugin/tests/configs.test.js
@@ -29,8 +29,8 @@ describe("rules", () => {
       .filter((file) => file.endsWith(".test.js"))
       .map((file) => file.replace(".test.js", ""));
 
-    expect(exportedRuleNames).toEqual(
-      expect.arrayContaining(ruleTestFilesWithoutExt)
+    expect(ruleTestFilesWithoutExt).toEqual(
+      expect.arrayContaining(exportedRuleNames)
     );
   });
 


### PR DESCRIPTION
## Checklist

- Addresses an existing open issue: None

Since this is an adjustment to an existing test assertion rather than a rule proposal or behavior change, I did not open a separate issue.

## Description

Hello! While reading `configs.test.js`, I noticed that the containment check in this assertion was reversed. As a result, the test could pass even when an exported rule did not have a corresponding test file.

This PR corrects the comparison direction so that every exported rule is checked for a corresponding test file.